### PR TITLE
Staging and sanitation of empty link objects in Prismic responses

### DIFF
--- a/lib/eventFetch.js
+++ b/lib/eventFetch.js
@@ -17,11 +17,17 @@ export function mapLinkList(linkList) {
   if (linkList) {
     return linkList.map((eventLink) => {
       const linkItem = {};
-      linkItem.label = eventLink.label ? eventLink.label.value : '';
-      linkItem.link = eventLink.link ? eventLink.link.value : '';
+      if (!eventLink.hasOwnProperty('label') || !eventLink.hasOwnProperty('link')) {
+        return undefined;
+      }
+      linkItem.title = (eventLink.label && eventLink.label.hasOwnProperty('value')) ?
+        eventLink.label.value : '';
+      linkItem.url = (eventLink.link && eventLink.link.hasOwnProperty('value')) ?
+        eventLink.link.value : '';
       return linkItem;
-    });
+    }).filter(l => l !== undefined);
   }
+
   return [];
 }
 

--- a/lib/eventFetch.spec.js
+++ b/lib/eventFetch.spec.js
@@ -51,12 +51,12 @@ describe('Data sanitation', () => {
         },
       }];
       expect(mapLinkList(linkList)).to.deep.equal([{
-        label: 'For full details please check out the meetup page',
-        link: 'http://www.meetup.com/London-React-User-Group/',
+        title: 'For full details please check out the meetup page',
+        url: 'http://www.meetup.com/London-React-User-Group/',
       }]);
     });
 
-    it('should correctly handle empty link document', () => {
+    it('should correctly omit empty link document', () => {
       const linkList = [{
         label: {
           type: 'Text',
@@ -68,11 +68,8 @@ describe('Data sanitation', () => {
         },
       }, {}];
       expect(mapLinkList(linkList)).to.deep.equal([{
-        label: 'For full details please check out the meetup page',
-        link: 'http://www.meetup.com/London-React-User-Group/',
-      }, {
-        label: '',
-        link: '',
+        title: 'For full details please check out the meetup page',
+        url: 'http://www.meetup.com/London-React-User-Group/',
       },
       ]);
     });


### PR DESCRIPTION
![tumblr_inline_o91si2pcdx1raprkq_500](https://cloud.githubusercontent.com/assets/487468/16305812/5652ac2c-3953-11e6-9b4b-53cbb2f40d26.gif)

This will now omit the whole empty link from the GraphQL response.

It's also a good idea to test Badger Brain changes with client app too.

### Pre-flight checklist

- [x] Unit tests
- [x] GraphiQL tested
- [x] Gif added


