### PR TITLE
Prismic Field-Specific Fetching

### DIFF
--- a/lib/eventFields.js
+++ b/lib/eventFields.js
@@ -6,7 +6,7 @@ import {
   GraphQLSchema,
 } from 'graphql';
 
-import { fetchEvent, fetchAll } from './fetch';
+import { getDocumentById, getDocumentsByType } from './fetch';
 
 const EventRelatedLinkType = new GraphQLObjectType({
   name: 'EventRelatedLink',
@@ -111,11 +111,11 @@ export const EventSchemaFields = {
     args: {
       id: { type: GraphQLString },
     },
-    resolve: fetchEvent,
+    resolve: getDocumentById('event'),
   },
   allEvents: {
     type: new GraphQLList(EventType),
     description: 'Request all Red Badger social events, past and upcoming',
-    resolve: fetchAll('event'),
+    resolve: getDocumentsByType('event'),
   },
 };

--- a/lib/eventFields.js
+++ b/lib/eventFields.js
@@ -6,7 +6,7 @@ import {
   GraphQLSchema,
 } from 'graphql';
 
-import { fetchEvent, fetchAllEvents } from './fetch';
+import { fetchEvent, fetchAll } from './fetch';
 
 const EventRelatedLinkType = new GraphQLObjectType({
   name: 'EventRelatedLink',
@@ -116,6 +116,6 @@ export const EventSchemaFields = {
   allEvents: {
     type: new GraphQLList(EventType),
     description: 'Request all Red Badger social events, past and upcoming',
-    resolve: fetchAllEvents,
+    resolve: fetchAll('event'),
   },
 };

--- a/lib/eventFields.spec.js
+++ b/lib/eventFields.spec.js
@@ -9,8 +9,8 @@ import {
 import eventsFixtures from '../test/fixtures/events.json';
 
 const mockfetch = {
-  fetchEvent: () => eventsFixtures.events[0],
-  fetchAllEvents: () => eventsFixtures.events,
+  getDocumentById: () => () => eventsFixtures.events[0],
+  getDocumentsByType: () => () => eventsFixtures.events,
 };
 
 const EventsFields = injectr('./../../lib/eventFields.js', {

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -59,7 +59,12 @@ const transformResult = curry((docType, results) =>
   results.map(mapAndSanitate(docType)));
 
 const getFieldsFromQuery = (type, fieldASTs) =>
-  map(field => `${type}.${field.name.value}`, fieldASTs[0].selectionSet.selections);
+  map(field => {
+    if (field.name.value === 'datetime') {
+      return `${type}.timestamp`;
+    }
+    return `${type}.${field.name.value}`;
+  }, fieldASTs[0].selectionSet.selections);
 
 const makeAPIRequest = async (query, ref, transformer) => {
   const api = await Prismic.api(PrismicConfig.apiEndpoint);

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -14,6 +14,9 @@ export function mapDate(timestamp) {
   };
 }
 
+const getFieldsFromQuery = (type, fieldASTs) =>
+  map(field => `${type}.${field.name.value}`, fieldASTs[0].selectionSet.selections);
+
 const makeAPIRequest = async (query, ref, transformer) => {
   try {
     const api = await Prismic.api(PrismicConfig.apiEndpoint);
@@ -23,12 +26,20 @@ const makeAPIRequest = async (query, ref, transformer) => {
   } catch (e) {}
 };
 
-export const fetchAll = type => async (_, args, req, ast) => {
-  const fields = map(field => `${type}.${field.name.value}`, ast.operation.selectionSet.selections[0].selectionSet.selections);
+export const getDocumentsByType = type => async (_, args, req, { fieldASTs }) => {
+  const fields = getFieldsFromQuery(type, fieldASTs);
   const query = api => api.fetch(fields)
     .query(Prismic.Predicates.at('document.type', type))
     .pageSize(100);
   return await makeAPIRequest(query, req.headers['x-preview'], transformResult(type));
+};
+
+export const getDocumentById = type => async (_, args, req, { fieldASTs }) => {
+  const fields = getFieldsFromQuery(type, fieldASTs);
+  const query = api => api.fetch(fields)
+    .query(Prismic.Predicates.at('document.id', args.id))
+  const results = await makeAPIRequest(query, req.headers['x-preview'], transformResult(type));
+  return results[0];
 };
 
 export function mapLinkList(linkList) {
@@ -50,8 +61,7 @@ export function mapLinkList(linkList) {
 }
 
 const transformResult = curry((docType, results) =>
-  results.map(mapAndSanitate(docType))
-);
+  results.map(mapAndSanitate(docType)));
 
 export const mapAndSanitate = curry((type, item) => {
   const imageField = (type === 'news') ? 'featureImage' : 'event-image'
@@ -75,30 +85,3 @@ export const mapAndSanitate = curry((type, item) => {
       item.data[type + '.' + imageField].value : null,
   };
 });
-
-async function fetchOne(_, args, req, docType) {
-  const ref = req.headers['x-preview'];
-
-  const api = await Prismic.api(PrismicConfig.apiEndpoint);
-  const res = await api.form('everything').ref(ref || api.master()).query(
-    Prismic.Predicates.at('document.id', args.id))
-    .submit();
-
-  if (res && res.results.length > 0) {
-    return mapAndSanitate(res.results[0], docType);
-  }
-
-  return {};
-}
-
-export async function fetchEvent(_, args, req) {
-  return fetchOne(_, args, req, 'event');
-}
-
-export async function fetchNewsArticle(_, args, req) {
-  return fetchOne(_, args, req, 'news');
-}
-
-export async function fetchAllNews() {
-  return fetchAll('news');
-}

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,4 +1,4 @@
-import { map } from 'ramda';
+import { map, curry } from 'ramda';
 import Prismic from 'prismic.io';
 import dateFns from 'date-fns';
 import { PrismicConfig } from './config/prismic.js';
@@ -14,24 +14,21 @@ export function mapDate(timestamp) {
   };
 }
 
-const makeAPIRequest = async (query, ref) => {
+const makeAPIRequest = async (query, ref, transformer) => {
   try {
     const api = await Prismic.api(PrismicConfig.apiEndpoint);
     const init = api.form('everything').ref(ref || api.master());
-    return await query(init).submit();
+    const { results } = await query(init).submit();
+    return transformer(results);
   } catch (e) {}
 };
 
-export const fetchAllEvents = async (_, args, req, ast) => {
-  const fields = map(field => `event.${field.name.value}`, ast.operation.selectionSet.selections[0].selectionSet.selections);
+export const fetchAll = type => async (_, args, req, ast) => {
+  const fields = map(field => `${type}.${field.name.value}`, ast.operation.selectionSet.selections[0].selectionSet.selections);
   const query = api => api.fetch(fields)
-    .query(Prismic.Predicates.at('document.type', 'event'))
+    .query(Prismic.Predicates.at('document.type', type))
     .pageSize(100);
-  const r = await makeAPIRequest(query, req.headers['x-preview']);
-  if (r.results.length > 0) {
-    const mappedList = r.results.map((item) => mapAndSanitate(item, 'event'));
-    return mappedList;
-  }
+  return await makeAPIRequest(query, req.headers['x-preview'], transformResult(type));
 };
 
 export function mapLinkList(linkList) {
@@ -52,9 +49,12 @@ export function mapLinkList(linkList) {
   return [];
 }
 
-export function mapAndSanitate(item, type) {
-  const imageField = (type === 'news') ? 'featureImage' : 'event-image'
+const transformResult = curry((docType, results) =>
+  results.map(mapAndSanitate(docType))
+);
 
+export const mapAndSanitate = curry((type, item) => {
+  const imageField = (type === 'news') ? 'featureImage' : 'event-image'
   return {
     id: item.id,
     slug: item.slug ? item.slug : null,
@@ -74,7 +74,7 @@ export function mapAndSanitate(item, type) {
     featureImageFilename: item.data[type + '.' + imageField] ?
       item.data[type + '.' + imageField].value : null,
   };
-}
+});
 
 async function fetchOne(_, args, req, docType) {
   const ref = req.headers['x-preview'];
@@ -86,21 +86,6 @@ async function fetchOne(_, args, req, docType) {
 
   if (res && res.results.length > 0) {
     return mapAndSanitate(res.results[0], docType);
-  }
-
-  return {};
-}
-
-async function fetchAll(docType) {
-  const api = await Prismic.api(PrismicConfig.apiEndpoint);
-  const res = await api.form('everything').ref(api.master()).query(Prismic
-    .Predicates.at('document.type', docType))
-    .pageSize(100) // TODO: implement pagination
-    .submit();
-
-  if (res && res.results.length > 0) {
-    const mappedList = res.results.map((item) => mapAndSanitate(item, docType));
-    return mappedList;
   }
 
   return {};

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,3 +1,4 @@
+import { map } from 'ramda';
 import Prismic from 'prismic.io';
 import dateFns from 'date-fns';
 import { PrismicConfig } from './config/prismic.js';
@@ -12,6 +13,26 @@ export function mapDate(timestamp) {
     year: dateFns.format(d, 'YYYY'),
   };
 }
+
+const makeAPIRequest = async (query, ref) => {
+  try {
+    const api = await Prismic.api(PrismicConfig.apiEndpoint);
+    const init = api.form('everything').ref(ref || api.master());
+    return await query(init).submit();
+  } catch (e) {}
+};
+
+export const fetchAllEvents = async (_, args, req, ast) => {
+  const fields = map(field => `event.${field.name.value}`, ast.operation.selectionSet.selections[0].selectionSet.selections);
+  const query = api => api.fetch(fields)
+    .query(Prismic.Predicates.at('document.type', 'event'))
+    .pageSize(100);
+  const r = await makeAPIRequest(query, req.headers['x-preview']);
+  if (r.results.length > 0) {
+    const mappedList = r.results.map((item) => mapAndSanitate(item, 'event'));
+    return mappedList;
+  }
+};
 
 export function mapLinkList(linkList) {
   if (linkList) {
@@ -87,10 +108,6 @@ async function fetchAll(docType) {
 
 export async function fetchEvent(_, args, req) {
   return fetchOne(_, args, req, 'event');
-}
-
-export async function fetchAllEvents() {
-  return fetchAll('event');
 }
 
 export async function fetchNewsArticle(_, args, req) {

--- a/lib/fetch.spec.js
+++ b/lib/fetch.spec.js
@@ -3,10 +3,8 @@ import nock from 'nock';
 import {
   mapAndSanitate,
   mapDate, mapLinkList,
-  fetchEvent,
-  fetchAllEvents,
-  fetchNewsArticle,
-  fetchAllNews
+  getDocumentsByType,
+  getDocumentById,
 } from './fetch';
 
 nock.emitter.on('no match', function(req) {
@@ -14,6 +12,22 @@ nock.emitter.on('no match', function(req) {
 });
 
 describe('Fetch', () => {
+  const executionContext = {
+    fieldASTs: [{
+      selectionSet: {
+        selections: [{
+          name: {
+            value: 'it works!',
+          },
+        }],
+      },
+    }],
+  };
+
+  const req = {
+    headers: {},
+  };
+
   beforeEach(() => {
     nock('https://rb-website-stage.prismic.io', {"encodedQueryParams":true})
       .get('/api')
@@ -24,21 +38,20 @@ describe('Fetch', () => {
     it('should fetch events', async () => {
       const docType = 'event';
       const scope = nock('https://rb-website-stage.prismic.io')
-        .get('/api/documents/search?page=1&pageSize=100&ref=V3UXpioAACQARLlk&q=%5B%5B%3Ad%20%3D%20at(document.type%2C%20%22' + docType + '%22)%5D%5D')
+        .get('/api/documents/search?page=1&pageSize=100&ref=V3UXpioAACQARLlk&fetch=event.it%20works!&q=%5B%5B%3Ad%20%3D%20at(document.type%2C%20%22event%22)%5D%5D')
         .reply(200, '{"results": []}');
 
-      const result = await fetchAllEvents();
-
+      await getDocumentsByType(docType)(null, null, req, executionContext);
       expect(scope.isDone()).to.be.true;
     });
 
     it('should fetch news', async () => {
       const docType = 'news';
       const scope = nock('https://rb-website-stage.prismic.io')
-        .get('/api/documents/search?page=1&pageSize=100&ref=V3UXpioAACQARLlk&q=%5B%5B%3Ad%20%3D%20at(document.type%2C%20%22' + docType + '%22)%5D%5D')
+        .get('/api/documents/search?page=1&pageSize=100&ref=V3UXpioAACQARLlk&fetch=news.it%20works!&q=%5B%5B%3Ad%20%3D%20at(document.type%2C%20%22news%22)%5D%5D')
         .reply(200, '{"results": []}');
 
-      const result = await fetchAllNews();
+      await getDocumentsByType(docType)(null, null, req, executionContext);
 
       expect(scope.isDone()).to.be.true;
     });
@@ -48,10 +61,10 @@ describe('Fetch', () => {
     it('should fetch an individual event', async () => {
       const id = 'falafels';
       const scope = nock('https://rb-website-stage.prismic.io')
-        .get('/api/documents/search?page=1&pageSize=20&ref=V3UXpioAACQARLlk&q=%5B%5B%3Ad%20%3D%20at(document.id%2C%20%22' + id + '%22)%5D%5D')
+        .get('/api/documents/search?page=1&pageSize=20&ref=V3UXpioAACQARLlk&fetch=event.it%20works!&q=%5B%5B%3Ad%20%3D%20at(document.id%2C%20%22' + id + '%22)%5D%5D')
         .reply(200, '{"results": []}');
 
-      const result = await fetchEvent(undefined, {id: id}, {headers: {}});
+      const result = await getDocumentById('event')(undefined, {id: id}, req, executionContext);
 
       expect(scope.isDone()).to.be.true;
     });
@@ -59,10 +72,10 @@ describe('Fetch', () => {
     it('should fetch an individual news article', async () => {
       const id = 'falafels';
       const scope = nock('https://rb-website-stage.prismic.io')
-        .get('/api/documents/search?page=1&pageSize=20&ref=V3UXpioAACQARLlk&q=%5B%5B%3Ad%20%3D%20at(document.id%2C%20%22' + id + '%22)%5D%5D')
+        .get('/api/documents/search?page=1&pageSize=20&ref=V3UXpioAACQARLlk&fetch=news.it%20works!&q=%5B%5B%3Ad%20%3D%20at(document.id%2C%20%22' + id + '%22)%5D%5D')
         .reply(200, '{"results": []}');
 
-      const result = await fetchNewsArticle(undefined, {id: id}, {headers: {}});
+      const result = await getDocumentById('news')(undefined, {id: id}, req, executionContext);
 
       expect(scope.isDone()).to.be.true;
     });
@@ -89,7 +102,7 @@ describe('Data sanitation', () => {
       body: [],
     };
 
-    expect(mapAndSanitate(event)).to.deep.equal(emptyResponse);
+    expect(mapAndSanitate('event', event)).to.deep.equal(emptyResponse);
   });
 
   it('should create datetime object of a correct format', () => {

--- a/lib/newsFields.js
+++ b/lib/newsFields.js
@@ -6,7 +6,7 @@ import {
 } from 'graphql';
 
 import { EventType } from './eventFields.js';
-import { fetchNewsArticle, fetchAll } from './fetch';
+import { getDocumentById, getDocumentsByType } from './fetch';
 
 export const NewsSchemaFields = {
   news: {
@@ -15,11 +15,11 @@ export const NewsSchemaFields = {
     args: {
       id: { type: GraphQLString },
     },
-    resolve: fetchNewsArticle,
+    resolve: getDocumentById('news'),
   },
   allNews: {
     type: new GraphQLList(EventType),
     description: 'Request all Red Badger news',
-    resolve: fetchAll('news'),
+    resolve: getDocumentsByType('news'),
   },
 };

--- a/lib/newsFields.js
+++ b/lib/newsFields.js
@@ -6,7 +6,7 @@ import {
 } from 'graphql';
 
 import { EventType } from './eventFields.js';
-import { fetchNewsArticle, fetchAllNews } from './fetch';
+import { fetchNewsArticle, fetchAll } from './fetch';
 
 export const NewsSchemaFields = {
   news: {
@@ -20,6 +20,6 @@ export const NewsSchemaFields = {
   allNews: {
     type: new GraphQLList(EventType),
     description: 'Request all Red Badger news',
-    resolve: fetchAllNews,
+    resolve: fetchAll('news'),
   },
 };

--- a/lib/newsFields.spec.js
+++ b/lib/newsFields.spec.js
@@ -9,8 +9,8 @@ import {
 import newsFixtures from '../test/fixtures/news.json';
 
 const mockfetch = {
-  fetchNewsArticle: () => newsFixtures.news[0],
-  fetchAllNews: () => newsFixtures.news,
+  getDocumentById: () => () => newsFixtures.news[0],
+  getDocumentsByType: () => () => newsFixtures.news,
 };
 
 const NewsFields = injectr('./../../lib/newsFields.js', {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "express-graphql": "^0.5.3",
     "express-prismic": "^1.1.1",
     "graphql": "^0.6.0",
-    "prismic.io": "^3.0.0"
+    "prismic.io": "^3.0.0",
+    "ramda": "^0.21.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
![penguin](https://cloud.githubusercontent.com/assets/849103/16579121/23646e08-4296-11e6-9d4c-c6bcb8d1c27d.gif)
- Bit of a refactor of the Prismic fetching mechanism.
- Only query for Prismic fields that are specified in the GraphQL query selection set.

### Pre-flight checklist
- [x] Unit tests
- [ ] Unit tests for previewing, transforming data, etc
- [x] GraphiQL tested
- [x] Client app tested
- [x] Gif added

