### PR TITLE
Tags

### DIFF
--- a/lib/event/eventFields.js
+++ b/lib/event/eventFields.js
@@ -97,13 +97,22 @@ export const EventSchemaFields = {
     type: EventType,
     description: 'Request a single Red Badger social event by its ID',
     args: {
-      id: { type: GraphQLString },
+      id: {
+        type: GraphQLString,
+        description: 'ID of a single event',
+      },
     },
     resolve: fetchEvent,
   },
   allEvents: {
     type: new GraphQLList(EventType),
     description: 'Request all Red Badger social events, past and upcoming',
+    args: {
+      tag: {
+        type: GraphQLString,
+        description: 'Get all events with this tag',
+      },
+    },
     resolve: fetchAllEvents,
   },
 };

--- a/lib/event/eventFields.spec.js
+++ b/lib/event/eventFields.spec.js
@@ -25,6 +25,29 @@ const EventsSchema = new GraphQLSchema({
 });
 
 describe('Event Queries', () => {
+  it('should be able to get events based on provided tag', async () => {
+    const query = `
+      query {
+        allEvents(tag: "meetup") {
+          title
+        }
+      }
+    `;
+
+    const result = await graphql(EventsSchema, query);
+
+    expect(result.data).to.deep.equal({
+      allEvents: [
+        {
+          title: 'David Wynne and Joe Stanton talking at London Node User Group',
+        },
+        {
+          title: 'ReactEurope 2016',
+        },
+      ],
+    });
+  });
+
   it('should be able to get all available events', async () => {
     const query = `
       query {
@@ -59,7 +82,7 @@ describe('Event Queries', () => {
     expect(result.data).to.deep.equal({
       allEvents: [
         {
-          tags: ['London Node', 'BBC Now'],
+          tags: ['London Node', 'BBC Now', 'meetup'],
           title: 'David Wynne and Joe Stanton talking at London Node User Group',
           slug: 'london-node-user-group',
           strapline: 'BBC Now ...that’s what I call Node!',
@@ -75,7 +98,7 @@ describe('Event Queries', () => {
           sponsors: [],
         },
         {
-          tags: [],
+          tags: ['conf', 'meetup'],
           title: 'ReactEurope 2016',
           slug: 'react-europe-2016',
           strapline: 'Red Badger are super excited to be sponsoring ReactEurope for the second year running!',

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -76,8 +76,10 @@ export function sanitizeSpeaker(json) {
 
 async function fetchOne(source, args, req, docType, sanitizeFunction) {
   const api = await Prismic.api(PrismicConfig.apiEndpoint);
-  const res = await api.form('everything').ref(api.master()).query(
-    Prismic.Predicates.at('document.id', args.id)
+  const res = await api
+  .form('everything')
+  .ref(api.master())
+  .query(Prismic.Predicates.at('document.id', args.id)
   )
   .submit();
 
@@ -88,12 +90,18 @@ async function fetchOne(source, args, req, docType, sanitizeFunction) {
   return {};
 }
 
-async function fetchAll(docType, sanitizeFunction) {
+async function fetchAll(docType, sanitizeFunction, args) {
+  const query = [Prismic.Predicates.at('document.type', docType)];
+  if (args && args.tag) {
+    query.push(Prismic.Predicates.at('document.tags', [args.tag]));
+  }
+
   const api = await Prismic.api(PrismicConfig.apiEndpoint);
-  const res = await api.form('everything').ref(api.master()).query(
-    Prismic.Predicates.at('document.type', docType)
-  )
-  .pageSize(100)
+  const res = await api
+  .form('everything')
+  .ref(api.master())
+  .query(query)
+  .pageSize(100) // TODO: implement pagination
   .submit();
 
   if (res && res.results.length > 0) {
@@ -135,8 +143,8 @@ export async function fetchSpeaker(source, args, req) {
 }
 
 /* Event */
-export async function fetchAllEvents() {
-  return fetchAll('event', sanitizeEventAndNews);
+export async function fetchAllEvents(_, args) {
+  return fetchAll('event', sanitizeEventAndNews, args);
 }
 
 export async function fetchEvent(source, args, req) {
@@ -144,8 +152,8 @@ export async function fetchEvent(source, args, req) {
 }
 
 /* News */
-export async function fetchAllNews() {
-  return fetchAll('news', sanitizeEventAndNews);
+export async function fetchAllNews(_, args) {
+  return fetchAll('news', sanitizeEventAndNews, args);
 }
 
 export async function fetchNewsArticle(source, args, req) {

--- a/lib/news/newsFields.js
+++ b/lib/news/newsFields.js
@@ -68,13 +68,22 @@ export const NewsSchemaFields = {
     type: NewsItemType,
     description: 'Request a single Red Badger news article by its ID',
     args: {
-      id: { type: GraphQLString },
+      id: {
+        type: GraphQLString,
+        description: 'ID of the news article to fetch',
+      },
     },
     resolve: fetchNewsArticle,
   },
   allNews: {
     type: new GraphQLList(NewsItemType),
     description: 'Request all Red Badger news',
+    args: {
+      tag: {
+        type: GraphQLString,
+        description: 'Get news articles with this tag',
+      },
+    },
     resolve: fetchAllNews,
   },
 };

--- a/lib/news/newsFields.spec.js
+++ b/lib/news/newsFields.spec.js
@@ -26,6 +26,30 @@ const NewsSchema = new GraphQLSchema({
 });
 
 describe('News Queries', () => {
+  it('should be able to get list of news articles based on tag', async () => {
+    const query = `
+      query {
+        allNews(tag: "awards") {
+          title
+        }
+      }
+    `;
+
+    const result = await graphql(NewsSchema, query);
+    console.log(result.data);
+
+    expect(result.data).to.deep.equal({
+      allNews: [
+        {
+          title: 'Cain discusses motivating staff, beyond the ‘carrot and stick’ of cold hard cash.',
+        },
+        {
+          title: 'Red Badger Shortlisted for Employee Engagement Award!',
+        },
+      ],
+    });
+  });
+
   it('should be able to get single news article based on ID', async () => {
     const query = `
       query {

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -2,7 +2,7 @@
   "events": [
     {
       "id": "123",
-      "tags": ["London Node", "BBC Now"],
+      "tags": ["London Node", "BBC Now", "meetup"],
       "title": "David Wynne and Joe Stanton talking at London Node User Group",
       "slug": "london-node-user-group",
       "strapline": "BBC Now ...that’s what I call Node!",
@@ -47,7 +47,7 @@
     },
     {
       "id": "456",
-      "tags": [],
+      "tags": ["conf", "meetup"],
       "title": "ReactEurope 2016",
       "slug": "react-europe-2016",
       "strapline": "Red Badger are super excited to be sponsoring ReactEurope for the second year running!",

--- a/test/fixtures/news.json
+++ b/test/fixtures/news.json
@@ -1,6 +1,7 @@
 {
   "allNews": [{
     "id": "123",
+    "tags": ["meetup"],
     "slug": "cain-discusses-motivating-staff-beyond-the-carrot-and-stick-of-cold-hard-cash.",
     "title": "Cain discusses motivating staff, beyond the ‘carrot and stick’ of cold hard cash.",
     "datetime": "2016-02-02T12:00:00+0000",
@@ -32,6 +33,7 @@
     "featureImageFilename": "soda-report2.jpg"
   }, {
     "id": "456",
+    "tags": ["awards"],
     "slug": "red-badger-shortlisted-for-employee-engagement-award",
     "title": "Red Badger Shortlisted for Employee Engagement Award!",
     "datetime": "2016-02-10T12:00:00+0000",


### PR DESCRIPTION
![giphy 1](https://cloud.githubusercontent.com/assets/487468/16922193/8a77e982-4d0c-11e6-8db3-cdc96faa38a7.gif)

# Motivation

All documents are taggable. We need a way to filter out documents based on a given tag. There should be granularity built in to only retrieve documents of a certain kind based on a tag.

For now we are implementing support for all list queries to accept optional `tag` argument.

In future we might want to implement a `Tag` interface type http://graphql.org/docs/api-reference-type-system/#graphqlinterfacetype

This is a re-implementation of https://github.com/redbadger/badger-brain/pull/33

### Pre-flight checklist

- [x] Unit tests
- [x] GraphiQL tested
- [x] Client app tested
- [x] Gif added


