### PR TITLE
Added schedule to event type

### DIFF
--- a/lib/event/eventFields.js
+++ b/lib/event/eventFields.js
@@ -17,9 +17,10 @@ import {
   DateTimeType,
   RelatedLinkType,
   LocationType,
+  ScheduleItemType,
 } from '../sharedTypes';
 
-import { mapDateTime, mapLinkList } from '../resolvers';
+import { mapDateTime, mapLinkList, mapScheduleList } from '../resolvers';
 
 export const EventType = new GraphQLObjectType({
   name: 'Event',
@@ -68,6 +69,11 @@ export const EventType = new GraphQLObjectType({
     endDateTime: {
       type: DateTimeType,
       resolve: mapDateTime('endDateTime'),
+    },
+    schedule: {
+      type: new GraphQLList(ScheduleItemType),
+      description: 'An array of schedule items that each have a date and text description',
+      resolve: mapScheduleList('schedule'),
     },
     body: {
       type: new GraphQLList(BodyStructuredTextType),

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -37,6 +37,7 @@ export function sanitizeEventAndNews(item, type) {
     body: get(`${type}.body`) || [],
     featureImageFilename: get(`${type}.${imageField}`),
     talks: get('event.talks') || [],
+    schedule: get(`${type}.schedule`) || [],
     location: {
       address: get('event.address'),
       coordinates: {

--- a/lib/fetch.spec.js
+++ b/lib/fetch.spec.js
@@ -83,6 +83,7 @@ describe('Data sanitation', () => {
       endDateTime: null,
       body: [],
       talks: [],
+      schedule: [],
       location: {
         address: null,
         coordinates: {

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -1,4 +1,5 @@
 import dateFns from 'date-fns';
+import { pathOr } from 'ramda';
 
 export const mapDateTime = fieldName => doc => {
   const timestamp = doc[fieldName];
@@ -27,5 +28,20 @@ export const mapLinkList = fieldName => doc => {
     linkItem.title = link.title || '';
     linkItem.url = link.url || '';
     return linkItem;
+  }).filter(l => l !== undefined);
+};
+
+export const mapScheduleList = fieldName => doc => {
+  const schedule = doc[fieldName];
+
+  if (!schedule) { return []; }
+  return schedule.map((item) => {
+    if (!item.hasOwnProperty('time') || !item.hasOwnProperty('text')) {
+      return undefined;
+    }
+    const scheduleItem = {};
+    scheduleItem.time = pathOr('', ['time', 'value'], item);
+    scheduleItem.text = pathOr('', ['text', 'value'], item);
+    return scheduleItem;
   }).filter(l => l !== undefined);
 };

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -21,7 +21,7 @@ export const mapLinkList = fieldName => doc => {
 
   if (!linkList) { return []; }
   return linkList.map((link) => {
-    if (!link.hasOwnProperty('title') || !link.hasOwnProperty('url')) {
+    if (!link.title || !link.url) {
       return undefined;
     }
     const linkItem = {};
@@ -36,12 +36,11 @@ export const mapScheduleList = fieldName => doc => {
 
   if (!schedule) { return []; }
   return schedule.map((item) => {
-    if (!item.hasOwnProperty('time') || !item.hasOwnProperty('text')) {
+    const datetime = pathOr('', ['datetime', 'value'], item);
+    const text = pathOr('', ['text', 'value'], item);
+    if (!datetime || !text) {
       return undefined;
     }
-    const scheduleItem = {};
-    scheduleItem.time = pathOr('', ['time', 'value'], item);
-    scheduleItem.text = pathOr('', ['text', 'value'], item);
-    return scheduleItem;
+    return { datetime, text };
   }).filter(l => l !== undefined);
 };

--- a/lib/resolvers.spec.js
+++ b/lib/resolvers.spec.js
@@ -65,11 +65,11 @@ describe('Resolvers', () => {
     beforeEach(() => {
       scheduleList = [
         {
-          time: { type: 'Timestamp', value: 'aaaa' },
+          datetime: { type: 'Timestamp', value: '2016-07-27T23:00:00+0000' },
           text: { type: 'Text', value: 'Pizza' },
         },
         {
-          time: { type: 'Timestamp', value: 'bbb' },
+          datetime: { type: 'Timestamp', value: '2016-08-27T23:00:00+0012' },
           text: { type: 'Text', value: 'Drinks' },
         },
       ];
@@ -81,11 +81,11 @@ describe('Resolvers', () => {
     it('should correctly map list of links', () => {
       expect(resolve(data)).to.deep.equal([
         {
-          time: 'aaaa',
+          datetime: '2016-07-27T23:00:00+0000',
           text: 'Pizza',
         },
         {
-          time: 'bbb',
+          datetime: '2016-08-27T23:00:00+0012',
           text: 'Drinks',
         },
       ]);

--- a/lib/resolvers.spec.js
+++ b/lib/resolvers.spec.js
@@ -1,4 +1,4 @@
-import { mapDateTime, mapLinkList } from './resolvers';
+import { mapDateTime, mapLinkList, mapScheduleList } from './resolvers';
 
 describe('Resolvers', () => {
   describe('#mapDateTime', () => {
@@ -54,6 +54,41 @@ describe('Resolvers', () => {
         title: 'For full details please check out the meetup page',
         url: 'http://www.meetup.com/London-React-User-Group/',
       }]);
+    });
+  });
+
+  describe('#mapScheduleList', () => {
+    let scheduleList;
+    let data;
+    let resolve;
+
+    beforeEach(() => {
+      scheduleList = [
+        {
+          time: { type: 'Timestamp', value: 'aaaa' },
+          text: { type: 'Text', value: 'Pizza' },
+        },
+        {
+          time: { type: 'Timestamp', value: 'bbb' },
+          text: { type: 'Text', value: 'Drinks' },
+        },
+      ];
+
+      data = { schedule: scheduleList };
+      resolve = mapScheduleList('schedule');
+    });
+
+    it('should correctly map list of links', () => {
+      expect(resolve(data)).to.deep.equal([
+        {
+          time: 'aaaa',
+          text: 'Pizza',
+        },
+        {
+          time: 'bbb',
+          text: 'Drinks',
+        },
+      ]);
     });
   });
 });

--- a/lib/sharedTypes.js
+++ b/lib/sharedTypes.js
@@ -40,6 +40,20 @@ export const LocationType = new GraphQLObjectType({
   },
 });
 
+export const ScheduleItemType = new GraphQLObjectType({
+  name: 'ScheduleItemType',
+  fields: {
+    time: {
+      description: 'The type of the schedule item',
+      type: GraphQLString,
+    },
+    text: {
+      type: GraphQLString,
+      description: 'The text description of the schedule item',
+    },
+  },
+});
+
 export const DateTimeType = new GraphQLObjectType({
   name: 'DateTime',
   fields: {

--- a/lib/sharedTypes.js
+++ b/lib/sharedTypes.js
@@ -43,8 +43,8 @@ export const LocationType = new GraphQLObjectType({
 export const ScheduleItemType = new GraphQLObjectType({
   name: 'ScheduleItemType',
   fields: {
-    time: {
-      description: 'The type of the schedule item',
+    datetime: {
+      description: 'The datetime of the schedule item',
       type: GraphQLString,
     },
     text: {

--- a/prismic/custom-types/events.json
+++ b/prismic/custom-types/events.json
@@ -82,7 +82,7 @@
       "fieldset" : "Event Schedule",
       "config" : {
         "fields" : {
-          "time" : {
+          "datetime" : {
             "type" : "Timestamp",
             "config" : {
               "placeholder" : "Timestamp"

--- a/prismic/custom-types/events.json
+++ b/prismic/custom-types/events.json
@@ -77,6 +77,26 @@
         }
       }
     },
+    "schedule" : {
+      "type" : "Group",
+      "fieldset" : "Event Schedule",
+      "config" : {
+        "fields" : {
+          "time" : {
+            "type" : "Timestamp",
+            "config" : {
+              "placeholder" : "Timestamp"
+            }
+          },
+          "text" : {
+            "type" : "Text",
+            "config" : {
+              "placeholder" : "The schedule item text"
+            }
+          }
+        }
+      }
+    },
     "internalLinks" : {
       "type" : "Group",
       "fieldset" : "Internal links",


### PR DESCRIPTION
# Motivation

@bkspace has just added a static schedule component to the React.London webpage as shown below:
<img width="367" alt="screen shot 2016-07-21 at 11 58 01" src="https://cloud.githubusercontent.com/assets/6062416/17020600/659aee7c-4f3a-11e6-973a-09bf68a83cc6.png">

This needs to be changed dynamically through Prismic and to do so there need to be changes from both the Badger Brain and React.London sides. This is a two phase process where the Prismic/BadgerBrain is altered followed by a query/data-mappings change on the React.London side.

# PR description
This PR is the first stage of this process. On Prismic I have added a 'schedule' attribute to our custom Event type. This schedule is a group of schedule items which comprise of both datetime and text as shown below:

<img width="264" alt="screen shot 2016-07-21 at 12 04 02" src="https://cloud.githubusercontent.com/assets/6062416/17020748/3c71c966-4f3b-11e6-9eb9-521a953b9e9f.png">

I altered the Event type on badger brain to include the event schedule. I also added a mapping function to parse the array of schedule items.

This schedule can now be queried for as follows:

```
query {
  allCommunities {
    events {
      schedule {
        datetime
        text
      }
    }
  }
}
```

Which will return:

```
{
  "data": {
    "allCommunities": [
      {
        "events": [
          {
            "schedule": [
              {
                "datetime": "2016-07-25T23:00:00+0000",
                "text": "Doors open for pizza and beers"
              },
              {
                "datetime": "2016-07-25T23:00:00+0000",
                "text": "Intro from Stu"
              },
              {
                "datetime": "2016-07-25T23:00:00+0000",
                "text": "Various speakers chat"
              }
            ]
          }
        ]
      }
    ]
  }
}
```

This data can then be consumed from the React.London side.