### PR TITLE
Added status type to event

### DIFF
--- a/lib/event/eventFields.js
+++ b/lib/event/eventFields.js
@@ -19,6 +19,7 @@ import {
   LocationType,
   ScheduleItemType,
   SponsorItemType,
+  StatusType,
 } from '../sharedTypes';
 import {
   mapDateTime,
@@ -72,6 +73,14 @@ export const EventType = new GraphQLObjectType({
     endDateTime: {
       type: DateTimeType,
       resolve: mapDateTime('endDateTime'),
+    },
+    ticketReleaseDate: {
+      type: DateTimeType,
+      resolve: mapDateTime('ticketReleaseDate'),
+    },
+    status: {
+      type: StatusType,
+      description: 'The status of the event',
     },
     schedule: {
       type: new GraphQLList(ScheduleItemType),

--- a/lib/event/eventFields.js
+++ b/lib/event/eventFields.js
@@ -19,7 +19,7 @@ import {
   LocationType,
   ScheduleItemType,
   SponsorItemType,
-  StatusType,
+  EventStatusType,
 } from '../sharedTypes';
 import {
   mapDateTime,
@@ -79,7 +79,7 @@ export const EventType = new GraphQLObjectType({
       resolve: mapDateTime('ticketReleaseDate'),
     },
     status: {
-      type: StatusType,
+      type: EventStatusType,
       description: 'The status of the event',
     },
     schedule: {

--- a/lib/event/eventFields.spec.js
+++ b/lib/event/eventFields.spec.js
@@ -45,6 +45,7 @@ describe('Event Queries', () => {
           status {
             enum
             summary
+            link
           }
           featureImageFilename
           location {
@@ -78,6 +79,7 @@ describe('Event Queries', () => {
           status: {
             enum: 'RELEASED',
             summary: 'A foo went to a bar',
+            link: 'http://foobar.com',
           },
           schedule: [],
           sponsors: [],
@@ -108,6 +110,7 @@ describe('Event Queries', () => {
           status: {
             enum: null,
             summary: null,
+            link: null,
           },
           sponsors: [{
             imageURL: 'http://react.london/img/SVG/Badger_Roundel.svg',

--- a/lib/event/eventFields.spec.js
+++ b/lib/event/eventFields.spec.js
@@ -42,6 +42,10 @@ describe('Event Queries', () => {
             imageURL
             name
           }
+          status {
+            enum
+            summary
+          }
           featureImageFilename
           location {
             address
@@ -71,6 +75,10 @@ describe('Event Queries', () => {
               longitude: '-0.08610963821411133',
             },
           },
+          status: {
+            enum: 'RELEASED',
+            summary: 'A foo went to a bar',
+          },
           schedule: [],
           sponsors: [],
         },
@@ -97,6 +105,10 @@ describe('Event Queries', () => {
             datetime: '2016-07-25T23:00:00+0000',
             text: 'Various speakers chat',
           }],
+          status: {
+            enum: null,
+            summary: null,
+          },
           sponsors: [{
             imageURL: 'http://react.london/img/SVG/Badger_Roundel.svg',
             websiteURL: 'http://red-badger.com',

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -29,6 +29,11 @@ export function sanitizeEventAndNews(item, type) {
     startDateTime: get(`${type}.timestamp`),
     endDateTime: pathOr(get(`${type}.timestamp`),
       ['data', `${type}.timestampEnd`, 'value'], item),
+    ticketReleaseDate: get(`${type}.ticketReleaseDate`),
+    status: {
+      enum: get(`${type}.statusEnum`),
+      summary: get(`${type}.statusSummary`),
+    },
     internalLinks: reformatLinkList((get(`${type}.internalLinks`))),
     externalLinks: reformatLinkList((get(`${type}.externalLinks`))),
     body: get(`${type}.body`) || [],

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -32,6 +32,7 @@ export function sanitizeEventAndNews(item, type) {
     ticketReleaseDate: get(`${type}.ticketReleaseDate`),
     status: {
       enum: get(`${type}.statusEnum`),
+      link: get(`${type}.statusLink`),
       summary: get(`${type}.statusSummary`),
     },
     internalLinks: reformatLinkList((get(`${type}.internalLinks`))),

--- a/lib/fetch.spec.js
+++ b/lib/fetch.spec.js
@@ -89,6 +89,7 @@ describe('Data sanitation', () => {
       status: {
         enum: null,
         summary: null,
+        link: null,
       },
       location: {
         address: null,

--- a/lib/fetch.spec.js
+++ b/lib/fetch.spec.js
@@ -81,10 +81,15 @@ describe('Data sanitation', () => {
       datetime: null,
       startDateTime: null,
       endDateTime: null,
+      ticketReleaseDate: null,
       body: [],
       talks: [],
       schedule: [],
       sponsors: [],
+      status: {
+        enum: null,
+        summary: null,
+      },
       location: {
         address: null,
         coordinates: {

--- a/lib/sharedTypes.js
+++ b/lib/sharedTypes.js
@@ -41,7 +41,7 @@ export const LocationType = new GraphQLObjectType({
 });
 
 const statusEnum = new GraphQLEnumType({
-  name: 'Status',
+  name: 'EventStatus',
   description: 'The enum types corresponding to the various statues of an event',
   values: {
     PRE_RELEASE: {
@@ -68,7 +68,7 @@ const statusEnum = new GraphQLEnumType({
 });
 
 export const StatusType = new GraphQLObjectType({
-  name: 'StatusType',
+  name: 'EventStatusType',
   fields: {
     enum: {
       type: statusEnum,

--- a/lib/sharedTypes.js
+++ b/lib/sharedTypes.js
@@ -70,7 +70,7 @@ const statusEnum = new GraphQLEnumType({
 export const StatusType = new GraphQLObjectType({
   name: 'StatusType',
   fields: {
-    status: {
+    enum: {
       type: statusEnum,
       description: 'The status of the event',
     },

--- a/lib/sharedTypes.js
+++ b/lib/sharedTypes.js
@@ -42,7 +42,7 @@ export const LocationType = new GraphQLObjectType({
 
 const statusEnum = new GraphQLEnumType({
   name: 'Status',
-  description: 'One of the films in the Star Wars Trilogy',
+  description: 'The enum types corresponding to the various statues of an event',
   values: {
     PRE_RELEASE: {
       value: 'PRE_RELEASE',

--- a/lib/sharedTypes.js
+++ b/lib/sharedTypes.js
@@ -67,7 +67,7 @@ const statusEnum = new GraphQLEnumType({
   },
 });
 
-export const StatusType = new GraphQLObjectType({
+export const EventStatusType = new GraphQLObjectType({
   name: 'EventStatusType',
   fields: {
     enum: {

--- a/lib/sharedTypes.js
+++ b/lib/sharedTypes.js
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLObjectType } from 'graphql';
+import { GraphQLString, GraphQLObjectType, GraphQLEnumType } from 'graphql';
 
 export const BodyStructuredTextType = new GraphQLObjectType({
   name: 'BodyStructuredText',
@@ -36,6 +36,51 @@ export const LocationType = new GraphQLObjectType({
     coordinates: {
       type: CoordinateType,
       description: 'The coordinates of the location',
+    },
+  },
+});
+
+const statusEnum = new GraphQLEnumType({
+  name: 'Status',
+  description: 'One of the films in the Star Wars Trilogy',
+  values: {
+    PRE_RELEASE: {
+      value: 'PRE_RELEASE',
+      description: 'The status before the tickets have been released',
+    },
+    RELEASED: {
+      value: 'RELEASED',
+      description: 'The status once the tickets have been released',
+    },
+    SOLD_OUT: {
+      value: 'SOLD_OUT',
+      description: 'The status once the tickets have all been sold out',
+    },
+    LIVE: {
+      value: 'LIVE',
+      description: 'The status when the event is currently happening',
+    },
+    ENDED: {
+      value: 'ENDED',
+      description: 'The status when the event has ended',
+    },
+  },
+});
+
+export const StatusType = new GraphQLObjectType({
+  name: 'StatusType',
+  fields: {
+    status: {
+      type: statusEnum,
+      description: 'The status of the event',
+    },
+    link: {
+      type: GraphQLString,
+      description: 'The action of the event status button',
+    },
+    summary: {
+      type: GraphQLString,
+      description: 'The summary text',
     },
   },
 });

--- a/lib/sharedTypes.js
+++ b/lib/sharedTypes.js
@@ -76,7 +76,7 @@ export const StatusType = new GraphQLObjectType({
     },
     link: {
       type: GraphQLString,
-      description: 'The action of the event status button',
+      description: 'The action of the event status',
     },
     summary: {
       type: GraphQLString,

--- a/prismic/custom-types/events.json
+++ b/prismic/custom-types/events.json
@@ -47,6 +47,33 @@
         "label" : "End date and time"
       }
     },
+    "ticketReleaseDate" : {
+      "type" : "Timestamp",
+      "config" : {
+        "placeholder" : "Ticket release date"
+      }
+    },
+    "status" : {
+      "type" : "Select",
+      "fieldset" : "The status of the event",
+      "config" : {
+        "label" : "Status",
+        "options" : [ "RELEASED", "SOLD_OUT", "LIVE", "ENDED" ],
+        "placeholder" : "PRE_RELEASE"
+      }
+    },
+    "link" : {
+      "type" : "Text",
+      "config" : {
+        "placeholder" : "Link URL"
+      }
+    },
+    "summary" : {
+      "type" : "Text",
+      "config" : {
+        "placeholder" : "Summary"
+      }
+    },
     "address" : {
       "type" : "Text",
       "fieldset" : "Event location",

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -8,6 +8,10 @@
       "strapline": "BBC Now ...that’s what I call Node!",
       "schedule": [],
       "sponsors": [],
+      "status": {
+        "enum": "RELEASED",
+        "summary": "A foo went to a bar"
+      },
       "externalLinks": [
         {
           "title": "London Node.js User Group",
@@ -52,6 +56,10 @@
       "slug": "react-europe-2016",
       "strapline": "Red Badger are super excited to be sponsoring ReactEurope for the second year running!",
       "featureImageFilename": "react-europe.jpg",
+      "status": {
+        "enum": null,
+        "summary": null
+      },
       "externalLinks": [
         {
           "title": "For more information please visit the conference page",

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -10,7 +10,8 @@
       "sponsors": [],
       "status": {
         "enum": "RELEASED",
-        "summary": "A foo went to a bar"
+        "summary": "A foo went to a bar",
+        "link": "http://foobar.com"
       },
       "externalLinks": [
         {
@@ -58,7 +59,8 @@
       "featureImageFilename": "react-europe.jpg",
       "status": {
         "enum": null,
-        "summary": null
+        "summary": null,
+        "link": null
       },
       "externalLinks": [
         {


### PR DESCRIPTION
![Alt Text](https://media.giphy.com/media/33iqmp5ATXT5m/giphy.gif)

Bonjour!

Allow for an event to be in a specific state:

PRE_RELEASE - Before the tickets are released...
RELEASED - When tickets are released...
SOLD_OUT - No more tickets left...
LIVE - Display/link to the live stream
ENDED - Link to the recording of the event.

On the client, each will correspond to a title & buttonText (1), with the summaryText & ticketReleaseDate coming directly from Prismic.

(1) Using an enum means the person updating the event in Prismic does not have to re-write (most probably the same) title/button text for each state change. The link (onButtonClick), will need to change on every state change.
 
<img width="475" alt="screen shot 2016-07-27 at 13 18 25" src="https://cloud.githubusercontent.com/assets/1695350/17174918/b1bdac7e-53fc-11e6-966c-e7e1ddefcd2f.png">
