### PR TITLE
Added waitingListOpen boolean to event type

### DIFF
--- a/lib/event/eventFields.js
+++ b/lib/event/eventFields.js
@@ -83,6 +83,10 @@ export const EventType = new GraphQLObjectType({
       type: GraphQLBoolean,
       description: 'A boolean to show whether tickets are availiable',
     },
+    waitingListOpen: {
+      type: GraphQLBoolean,
+      description: 'A boolean to show whether the waiting list is open',
+    },
     schedule: {
       type: new GraphQLList(ScheduleItemType),
       description: 'An array of schedule items that each have a date and text description',

--- a/lib/event/eventFields.spec.js
+++ b/lib/event/eventFields.spec.js
@@ -71,6 +71,7 @@ describe('Event Queries', () => {
             text
           }
           ticketsAvailable
+          waitingListOpen
           sponsors {
             websiteURL
             imageURL
@@ -130,6 +131,7 @@ describe('Event Queries', () => {
             date: '24',
           },
           ticketsAvailable: false,
+          waitingListOpen: false,
           schedule: [],
           sponsors: [],
         },
@@ -168,6 +170,7 @@ describe('Event Queries', () => {
             text: 'Various speakers chat',
           }],
           ticketsAvailable: false,
+          waitingListOpen: false,
           sponsors: [{
             imageURL: 'http://react.london/img/SVG/Badger_Roundel.svg',
             websiteURL: 'http://red-badger.com',

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -33,6 +33,7 @@ export function sanitizeEventAndNews(item, type) {
       ['data', `${type}.timestampEnd`, 'value'], item),
     ticketReleaseDate: get(`${type}.ticketReleaseDate`),
     ticketsAvailable: get(`${type}.ticketsAvailable`) || false,
+    waitingListOpen: get(`${type}.waitingListOpen`) || false,
     internalLinks: reformatLinkList((get(`${type}.internalLinks`))),
     externalLinks: reformatLinkList((get(`${type}.externalLinks`))),
     body: get(`${type}.body`) || [],

--- a/lib/fetch.spec.js
+++ b/lib/fetch.spec.js
@@ -84,6 +84,7 @@ describe('Data sanitation', () => {
       endDateTime: null,
       ticketReleaseDate: null,
       ticketsAvailable: false,
+      waitingListOpen: false,
       body: [],
       talks: [],
       schedule: [],

--- a/prismic/custom-types/events.json
+++ b/prismic/custom-types/events.json
@@ -61,6 +61,14 @@
         "options" : [ false, true ]
       }
     },
+    "waitingListOpen" : {
+      "type" : "Select",
+      "fieldset" : "A boolean showing whether the waiting list is open",
+      "config" : {
+        "label" : "Waiting List Open",
+        "options" : [ false, true ]
+      }
+    },
     "address" : {
       "type" : "Text",
       "fieldset" : "Event location",

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -47,6 +47,7 @@
       ],
       "ticketReleaseDate": "2013-07-24T12:00:00.000Z",
       "ticketsAvailable": false,
+      "waitingListOpen": false,
       "featureImageFilename": "profile_DW_thumb.jpg",
       "body": "The Red Badger tech team talk about how Node powered the new BBC Now homepage pilot.",
       "datetime": {
@@ -86,6 +87,7 @@
       ],
       "ticketReleaseDate": "2013-07-24T12:00:00.000Z",
       "ticketsAvailable": false,
+      "waitingListOpen": false,
       "schedule": [
         {
           "datetime": {


### PR DESCRIPTION
# Motivation
After a discussion with Amy, Tania and Sammy it was decided that a new 'switch' will be needed on the prismic site to enable the entire ticket release process. This boolean is 'waitingListOpen'.

The current process is then:

## Step 1

- Amy adds Event Start Time
- Amy adds Event End Time
- Amy adds Ticket Release Time
- Amy sets tickets available to False.
- Amy sets the event link to an empty string.
- Amy sets the streaming link to an empty string.
- Amy sets waiting list open to False.
- The current time is before the Ticket Release Time.

![screen shot 2016-07-28 at 16 17 41](https://cloud.githubusercontent.com/assets/6062416/17218183/d58598d2-54de-11e6-94d0-160cfa0ef9eb.png)

## Step 2

- Amy sets tickets available to True.
- Amy sets the event link to the relevant site (EventBrite/Facebook etc).
- The current time is after the Ticket Release Time.

![screen shot 2016-07-28 at 16 20 09](https://cloud.githubusercontent.com/assets/6062416/17218285/2ca9248a-54df-11e6-87e9-0611a5703158.png)

## Step 3

- Amy sets tickets available to False.
- Amy sets waiting list open to True

![screen shot 2016-07-28 at 16 20 54](https://cloud.githubusercontent.com/assets/6062416/17218334/4a5f894c-54df-11e6-947f-105cab1eca87.png)

## Step 4

- Amy sets waiting list open to False

![screen shot 2016-07-28 at 16 23 44](https://cloud.githubusercontent.com/assets/6062416/17218431/ab8ebbca-54df-11e6-9d58-f19a15c8336e.png)

## Step 5

- Amy sets the streaming link to the relevant youtube link

![screen shot 2016-07-28 at 16 25 11](https://cloud.githubusercontent.com/assets/6062416/17218490/dfa27a14-54df-11e6-9c58-12f39f17d029.png)

## Step 6

- The current time is after the event end time

![screen shot 2016-07-28 at 16 25 39](https://cloud.githubusercontent.com/assets/6062416/17218509/f1236924-54df-11e6-846e-97b6808a83df.png)

# Thoughts

This may be relatively tricky to program bearing in mind that Prismic does not allow us to have mandatory fields. Another suggestion would be to edit all the fields manually.

For example, in Prismic, the user could edit the button text, button link, event status title etc. However, this would result in a process that requires much more manual work.