### PR TITLE
Made default option false for event type booleans

### DIFF
--- a/prismic/custom-types/events.json
+++ b/prismic/custom-types/events.json
@@ -58,7 +58,8 @@
       "fieldset" : "A boolean showing whether the tickets are availiable",
       "config" : {
         "label" : "Tickets Available",
-        "options" : [ false, true ]
+        "options" : [ "true" ],
+        "placeholder" : "false"
       }
     },
     "waitingListOpen" : {
@@ -66,7 +67,8 @@
       "fieldset" : "A boolean showing whether the waiting list is open",
       "config" : {
         "label" : "Waiting List Open",
-        "options" : [ false, true ]
+        "options" : [ "true" ],
+        "placeholder" : "false"
       }
     },
     "address" : {


### PR DESCRIPTION
# Motivation
On prismic currently, the default option is an empty string which can be selected. To prevent human error, this will be defaulted to false always. 

### Pre-flight checklist

- [x] Unit tests
- [x] GraphiQL tested
- [x] Client app tested
- [ ] Gif added


