### PR TITLE
Allow users to mark events as conference events.

### DIFF
--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -25,6 +25,7 @@ function sanitizeEventAndNews(item, type) {
     id: item.id,
     slug: item.slug || null,
     tags: item.tags || [],
+    eventType: get(`${type}.eventType`),
     title: get(`${type}.title`),
     strapline: get(`${type}.strapline`),
     datetime: get(`${type}.timestamp`),

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -12,16 +12,17 @@ import {
 describe('data/sanitize', () => {
   describe('sanitizeEvent', () => {
     it('should sanitate empty fields', () => {
-      const event = {
+      const event = deepFreeze({
         id: '123',
         data: {},
-      };
+      });
 
-      const emptyResponse = deepFreeze({
+      const emptyResponse = {
         id: '123',
         tags: [],
         title: null,
         slug: null,
+        eventType: null,
         strapline: null,
         featureImageFilename: null,
         internalLinks: [],
@@ -43,7 +44,59 @@ describe('data/sanitize', () => {
             longitude: null,
           },
         },
+      };
+
+      expect(sanitizeEvent(event)).to.deep.equal(emptyResponse);
+    });
+
+    it('should extract real values', () => {
+      const event = deepFreeze({
+        id: '123',
+        slug: 'some-event',
+        tags: ['tag1', 'tag2'],
+        data: {
+          'event.title': { value: 'Event Title' },
+          'event.eventType': { value: 'Meetup' },
+          'event.strapline': { value: 'A strapline!' },
+          'event.event-image': { value: 'foo.png' },
+          'event.body': { value: ['body'] },
+          'event.ticketsAvailable': { value: 'ticketsAvailable' },
+          'event.waitingListOpen': { value: 'waitingListOpen' },
+          'event.address': { value: 'an address' },
+          'event.sponsors': { value: ['event', 'sponsor'] },
+          'event.schedule': { value: ['event', 'schedule'] },
+          'event.talks': { value: ['event', 'talks'] },
+        },
       });
+
+      const emptyResponse = {
+        id: '123',
+        tags: ['tag1', 'tag2'],
+        title: 'Event Title',
+        slug: 'some-event',
+        eventType: 'Meetup',
+        strapline: 'A strapline!',
+        featureImageFilename: 'foo.png',
+        internalLinks: [],
+        externalLinks: [],
+        datetime: null,
+        startDateTime: null,
+        endDateTime: null,
+        ticketReleaseDate: null,
+        ticketsAvailable: 'ticketsAvailable',
+        waitingListOpen: 'waitingListOpen',
+        body: ['body'],
+        talks: ['event', 'talks'],
+        schedule: ['event', 'schedule'],
+        sponsors: ['event', 'sponsor'],
+        location: {
+          address: 'an address',
+          coordinates: {
+            latitude: null,
+            longitude: null,
+          },
+        },
+      };
 
       expect(sanitizeEvent(event)).to.deep.equal(emptyResponse);
     });

--- a/lib/interfaces/event/index.js
+++ b/lib/interfaces/event/index.js
@@ -28,6 +28,10 @@ export const eventTypeFields = {
     type: new GraphQLNonNull(GraphQLString),
     description: 'URL friendly representation of the event title',
   },
+  eventType: {
+    type: GraphQLString,
+    description: 'The type of the event. For example "Conference" or "Meetup"',
+  },
   tags: {
     type: new GraphQLList(GraphQLString),
     description: 'List of tags related the event',

--- a/prismic/custom-types/events.json
+++ b/prismic/custom-types/events.json
@@ -9,7 +9,7 @@
     },
     "title" : {
       "type" : "Text",
-      "fieldset" : "Title",
+      "fieldset" : "Details",
       "config" : {
         "label" : "Title of Event"
       }
@@ -24,6 +24,14 @@
       "type" : "Text",
       "config" : {
         "label" : "Feature Image"
+      }
+    },
+    "eventType" : {
+      "type" : "Select",
+      "config" : {
+        "label" : "Event Type",
+        "options" : [ "Meetup", "Conference" ],
+        "placeholder": "Other"
       }
     },
     "body" : {


### PR DESCRIPTION
![pikachu-show](https://cloud.githubusercontent.com/assets/6134406/17552629/eddc4d62-5ef8-11e6-9584-42c059ae396e.gif)

- [x] New enum field in prismic
- [x] Field exposed in badger brain
- [x] Test sanitizeEvent

## Test plan

- Edit an event in prismic, selecting an `eventType` for it from the drop down select.
- Query badger-brain for the event, including the `eventType` field. The value you picked should be present. Events without a value (i.e. they are set to "other") return null for this property.