### PR TITLE
Add partner type

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -6,6 +6,7 @@ import {
   sanitizeCommunity,
   sanitizeSpeaker,
   sanitizeTalk,
+  sanitizePartner,
 } from './sanitize';
 
 async function fetchOne(docType, sanitizeFunction, args) {
@@ -87,4 +88,13 @@ export function fetchAllTalks() {
 // TODO: Test
 export function fetchTalk(args) {
   return fetchOne('talk', sanitizeTalk, args);
+}
+
+// TODO: Test? lol
+export function fetchAllPartners(args) {
+  return fetchAll('partner', sanitizePartner, args);
+}
+
+export function fetchPartner(args) {
+  return fetchOne('partner', sanitizePartner, args);
 }

--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -77,9 +77,10 @@ export function sanitizePartner(json) {
     id: json.uid,
     name: get('partner.name'),
     level: get('partner.level'),
-    description: get('partner.description').substr(0, 50),
+    description: get('partner.description'),
     partnerURL: get('partner.partnerURL'),
     imageURL: get('partner.imageURL'),
+    jobs: get('partner.jobs') || [],
   };
 }
 
@@ -108,4 +109,3 @@ export function sanitizeSpeaker(json) {
     imageURL: get('speaker.imageURL'),
   };
 }
-

--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -42,6 +42,7 @@ function sanitizeEventAndNews(item, type) {
     talks: get('event.talks') || [],
     schedule: get(`${type}.schedule`) || [],
     sponsors: get(`${type}.sponsors`) || [],
+    partners: get(`${type}.partners`) || [],
     location: {
       address: get('event.address'),
       coordinates: {
@@ -67,6 +68,18 @@ export function sanitizeTalk(json) {
     title: get('talk.title'),
     summary: get('talk.summary'),
     speakers: get('talk.speakers'),
+  };
+}
+
+export function sanitizePartner(json) {
+  const get = makeGetter(json);
+  return {
+    id: json.uid,
+    name: get('partner.name'),
+    level: get('partner.level'),
+    description: get('partner.description').substr(0, 50),
+    partnerURL: get('partner.partnerURL'),
+    imageURL: get('partner.imageURL'),
   };
 }
 

--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -74,7 +74,7 @@ export function sanitizeTalk(json) {
 export function sanitizePartner(json) {
   const get = makeGetter(json);
   return {
-    id: json.uid,
+    id: json.id,
     name: get('partner.name'),
     level: get('partner.level'),
     description: get('partner.description'),

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -172,7 +172,7 @@ describe('data/sanitize', () => {
   describe('sanitizePartner', () => {
     it('converts the raw json provied by prismic to be readable by graphql', () => {
       const rawData = {
-        uid: 'exampleId',
+        id: 'exampleId',
         data: {
           'partner.name': { value: 'exampleName' },
           'partner.level': { value: 'exampleLevel' },
@@ -196,7 +196,7 @@ describe('data/sanitize', () => {
 
     it('returns the default values if the fields are not passed from prismisc', () => {
       const rawData = {
-        uid: null,
+        id: null,
         data: {},
       };
       const result = sanitizePartner(rawData);

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -7,6 +7,7 @@ import {
   sanitizeSpeaker,
   sanitizeTalk,
   reformatLinkList,
+  sanitizePartner,
 } from './sanitize';
 
 describe('data/sanitize', () => {
@@ -164,6 +165,49 @@ describe('data/sanitize', () => {
         blogURL: 'ggg',
         imageURL: 'hhh',
         id: 'exampleId',
+      });
+    });
+  });
+
+  describe('sanitizePartner', () => {
+    it('converts the raw json provied by prismic to be readable by graphql', () => {
+      const rawData = {
+        uid: 'exampleId',
+        data: {
+          'partner.name': { value: 'exampleName' },
+          'partner.level': { value: 'exampleLevel' },
+          'partner.description': { value: 'exampleDescription' },
+          'partner.partnerURL': { value: 'examplePartnerURL' },
+          'partner.imageURL': { value: 'exampleImageURL' },
+          'partner.jobs': { value: ['job1', 'job2'] },
+        },
+      };
+      const result = sanitizePartner(rawData);
+      expect(result).to.deep.equal({
+        id: 'exampleId',
+        name: 'exampleName',
+        level: 'exampleLevel',
+        description: 'exampleDescription',
+        partnerURL: 'examplePartnerURL',
+        imageURL: 'exampleImageURL',
+        jobs: ['job1', 'job2'],
+      });
+    });
+
+    it('returns the default values if the fields are not passed from prismisc', () => {
+      const rawData = {
+        uid: null,
+        data: {},
+      };
+      const result = sanitizePartner(rawData);
+      expect(result).to.deep.equal({
+        id: null,
+        name: null,
+        level: null,
+        description: null,
+        partnerURL: null,
+        imageURL: null,
+        jobs: [],
       });
     });
   });

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -68,6 +68,7 @@ describe('data/sanitize', () => {
           'event.sponsors': { value: ['event', 'sponsor'] },
           'event.schedule': { value: ['event', 'schedule'] },
           'event.talks': { value: ['event', 'talks'] },
+          'event.partners': { value: ['partner1', 'partner2'] },
         },
       });
 
@@ -90,7 +91,7 @@ describe('data/sanitize', () => {
         body: ['body'],
         talks: ['event', 'talks'],
         schedule: ['event', 'schedule'],
-        partners: [],
+        partners: ['partner1', 'partner2'],
         sponsors: ['event', 'sponsor'],
         location: {
           address: 'an address',

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -36,6 +36,7 @@ describe('data/sanitize', () => {
         body: [],
         talks: [],
         schedule: [],
+        partners: [],
         sponsors: [],
         location: {
           address: null,
@@ -88,6 +89,7 @@ describe('data/sanitize', () => {
         body: ['body'],
         talks: ['event', 'talks'],
         schedule: ['event', 'schedule'],
+        partners: [],
         sponsors: ['event', 'sponsor'],
         location: {
           address: 'an address',

--- a/lib/interfaces/event/index.js
+++ b/lib/interfaces/event/index.js
@@ -14,8 +14,9 @@ import {
   ScheduleItemType,
   SponsorItemType,
 } from '../../sharedTypes';
-import { fetchTalk } from '../../fetch';
+import { fetchTalk, fetchPartner } from '../../fetch';
 import { TalkType } from '../../talk/talkFields';
+import { EventPartnerType } from '../../partner/partnerFields';
 import { BasicEventType } from '../../basicEvent';
 import { mapDateTime, mapItemList } from '../../resolvers';
 
@@ -112,6 +113,19 @@ export const eventTypeFields = {
         return event.talks.map((result) => {
           const id = pathOr('', ['data', 'value', 'document', 'id'], result);
           return fetchTalk({ id });
+        });
+      }
+      return [];
+    },
+  },
+  partners: {
+    type: new GraphQLList(EventPartnerType),
+    description: 'List of partners for the event',
+    resolve(event) {
+      if (event && event.partners) {
+        return event.partners.map((result) => {
+          const id = pathOr('', ['data', 'value', 'document', 'id'], result);
+          return fetchPartner({ id });
         });
       }
       return [];

--- a/lib/partner/partnerFields.js
+++ b/lib/partner/partnerFields.js
@@ -3,6 +3,7 @@ import {
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
+  GraphQLEnumType,
 } from 'graphql';
 
 import { JobType } from '../sharedTypes';
@@ -46,13 +47,23 @@ export const PartnerType = new GraphQLObjectType({
 
 const DEFAULT_PARTNER_LEVEL = 'Supporter';
 
+const LevelType = new GraphQLEnumType({
+  name: 'LevelType',
+  values: {
+    Supporter: { value: 'Supporter' },
+    Gold: { value: 'Gold' },
+    Silver: { value: 'Silver' },
+    Bronze: { value: 'Bronze' },
+  },
+});
+
 export const EventPartnerType = new GraphQLObjectType({
   name: 'EventPartner',
   fields: {
     ...PartnerTypeFields,
     level: {
       name: 'level',
-      type: GraphQLString,
+      type: LevelType,
       resolve({ level }) {
         return level || DEFAULT_PARTNER_LEVEL;
       },

--- a/lib/partner/partnerFields.js
+++ b/lib/partner/partnerFields.js
@@ -6,8 +6,7 @@ import {
 } from 'graphql';
 
 import { JobType } from '../sharedTypes';
-
-import { fetchAllPartners } from '../fetch';
+import { fetchAllPartners, fetchPartner } from '../fetch';
 import { mapItemList } from '../resolvers';
 
 const PartnerTypeFields = {
@@ -62,6 +61,14 @@ export const EventPartnerType = new GraphQLObjectType({
 });
 
 export const PartnerSchemaFields = {
+  partner: {
+    type: PartnerType,
+    description: 'Request a partner by their id',
+    args: {
+      id: { type: GraphQLString },
+    },
+    resolve: (source, args) => fetchPartner(args),
+  },
   allPartners: {
     type: new GraphQLList(PartnerType),
     description: 'Request all partners',

--- a/lib/partner/partnerFields.js
+++ b/lib/partner/partnerFields.js
@@ -5,7 +5,10 @@ import {
   GraphQLObjectType,
 } from 'graphql';
 
+import { JobType } from '../sharedTypes';
+
 import { fetchAllPartners } from '../fetch';
+import { mapItemList } from '../resolvers';
 
 const PartnerTypeFields = {
   id: {
@@ -27,6 +30,11 @@ const PartnerTypeFields = {
   imageURL: {
     type: new GraphQLNonNull(GraphQLString),
     description: 'URL for partner logo',
+  },
+  jobs: {
+    type: new GraphQLList(JobType),
+    description: 'List of partner jobs',
+    resolve: mapItemList('jobs'),
   },
 };
 

--- a/lib/partner/partnerFields.js
+++ b/lib/partner/partnerFields.js
@@ -1,0 +1,62 @@
+import {
+  GraphQLString,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+} from 'graphql';
+
+import { fetchAllPartners } from '../fetch';
+
+const PartnerTypeFields = {
+  id: {
+    type: GraphQLString,
+    description: 'Unique id of partner',
+  },
+  name: {
+    type: new GraphQLNonNull(GraphQLString),
+    description: 'Name of partner',
+  },
+  description: {
+    type: GraphQLString,
+    description: 'Description of partner',
+  },
+  partnerURL: {
+    type: GraphQLString,
+    description: 'URL for partner homepage',
+  },
+  imageURL: {
+    type: new GraphQLNonNull(GraphQLString),
+    description: 'URL for partner logo',
+  },
+};
+
+export const PartnerType = new GraphQLObjectType({
+  name: 'Partner',
+  fields: {
+    ...PartnerTypeFields,
+  },
+});
+
+const DEFAULT_PARTNER_LEVEL = 'Supporter';
+
+export const EventPartnerType = new GraphQLObjectType({
+  name: 'EventPartner',
+  fields: {
+    ...PartnerTypeFields,
+    level: {
+      name: 'level',
+      type: GraphQLString,
+      resolve({ level }) {
+        return level || DEFAULT_PARTNER_LEVEL;
+      },
+    },
+  },
+});
+
+export const PartnerSchemaFields = {
+  allPartners: {
+    type: new GraphQLList(PartnerType),
+    description: 'Request all partners',
+    resolve: fetchAllPartners,
+  },
+};

--- a/lib/partner/partnerFields.js
+++ b/lib/partner/partnerFields.js
@@ -1,7 +1,6 @@
 import {
   GraphQLString,
   GraphQLList,
-  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLEnumType,
 } from 'graphql';
@@ -16,7 +15,7 @@ const PartnerTypeFields = {
     description: 'Unique id of partner',
   },
   name: {
-    type: new GraphQLNonNull(GraphQLString),
+    type: GraphQLString,
     description: 'Name of partner',
   },
   description: {
@@ -28,7 +27,7 @@ const PartnerTypeFields = {
     description: 'URL for partner homepage',
   },
   imageURL: {
-    type: new GraphQLNonNull(GraphQLString),
+    type: GraphQLString,
     description: 'URL for partner logo',
   },
   jobs: {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -8,6 +8,7 @@ import { NewsSchemaFields } from './news/newsFields';
 import { CommunitySchemaFields } from './community/communityFields';
 import { SpeakerSchemaFields } from './speaker/speakerFields';
 import { TalkSchemaFields } from './talk/talkFields';
+import { PartnerSchemaFields } from './partner/partnerFields';
 
 export const Schema = new GraphQLSchema({
   query: new GraphQLObjectType({
@@ -18,6 +19,7 @@ export const Schema = new GraphQLSchema({
       CommunitySchemaFields,
       SpeakerSchemaFields,
       TalkSchemaFields,
+      PartnerSchemaFields,
     ),
   }),
 });

--- a/lib/sharedTypes.js
+++ b/lib/sharedTypes.js
@@ -26,6 +26,24 @@ export const CoordinateType = new GraphQLObjectType({
   },
 });
 
+export const JobType = new GraphQLObjectType({
+  name: 'JobType',
+  fields: {
+    title: {
+      type: GraphQLString,
+      description: 'The job title',
+    },
+    location: {
+      type: GraphQLString,
+      description: 'The job location',
+    },
+    description: {
+      type: GraphQLString,
+      description: 'The job description',
+    },
+  },
+});
+
 export const LocationType = new GraphQLObjectType({
   name: 'LocationType',
   fields: {

--- a/prismic/custom-types/events.json
+++ b/prismic/custom-types/events.json
@@ -208,6 +208,30 @@
           }
         }
       }
+    },
+    "events" : {
+      "type" : "Group",
+      "fieldset" : "Event Partners",
+      "config" : {
+        "fields" : {
+          "data" : {
+            "type" : "Link",
+            "config" : {
+              "select" : "document",
+              "customtypes" : [ "partner" ],
+              "placeholder" : "Link to a partner"
+            }
+          },
+          "level" : {
+            "type" : "Select",
+            "config" : {
+              "label" : "Partner Level",
+              "options" : [ "Bronze", "Silver", "Gold" ],
+              "placeholder" : "Supporter"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/prismic/custom-types/partner.json
+++ b/prismic/custom-types/partner.json
@@ -31,6 +31,32 @@
       "config" : {
         "label" : "Image URL"
       }
+    },
+    "jobs" : {
+      "type" : "Group",
+      "fieldset" : "Partner Jobs",
+      "config" : {
+        "fields" : {
+          "title" : {
+            "type" : "Text",
+            "config" : {
+              "label" : "Job Title"
+            }
+          },
+          "location" : {
+            "type" : "Text",
+            "config" : {
+              "label" : "Job location"
+            }
+          },
+          "description" : {
+            "type" : "Text",
+            "config" : {
+              "label" : "Job description"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/prismic/custom-types/partner.json
+++ b/prismic/custom-types/partner.json
@@ -1,0 +1,44 @@
+{
+  "Main" : {
+    "uid" : {
+      "type" : "UID",
+      "fieldset" : "UID",
+      "config" : {
+        "placeholder" : "Leave blank to auto generate"
+      }
+    },
+    "name" : {
+      "type" : "Text",
+      "fieldset" : "Partner Info",
+      "config" : {
+        "label" : "Partner Name"
+      }
+    },
+    "level" : {
+      "type" : "Select",
+      "config" : {
+        "label" : "Partner Level",
+        "options" : [ "Bronze", "Silver", "Gold" ],
+        "placeholder" : "Supporter"
+      }
+    },
+    "description" : {
+      "type" : "Text",
+      "config" : {
+        "label" : "Description (Max 50 Characters)"
+      }
+    },
+    "partnerURL" : {
+      "type" : "Text",
+      "config" : {
+        "label" : "Partner URL"
+      }
+    },
+    "imageURL" : {
+      "type" : "Text",
+      "config" : {
+        "label" : "Image URL"
+      }
+    }
+  }
+}

--- a/prismic/custom-types/partner.json
+++ b/prismic/custom-types/partner.json
@@ -14,14 +14,6 @@
         "label" : "Partner Name"
       }
     },
-    "level" : {
-      "type" : "Select",
-      "config" : {
-        "label" : "Partner Level",
-        "options" : [ "Bronze", "Silver", "Gold" ],
-        "placeholder" : "Supporter"
-      }
-    },
     "description" : {
       "type" : "Text",
       "config" : {
@@ -38,20 +30,6 @@
       "type" : "Text",
       "config" : {
         "label" : "Image URL"
-      }
-    },
-    "event" : {
-      "type" : "Group",
-      "config" : {
-        "fields" : {
-          "data" : {
-            "type" : "Link",
-            "config" : {
-              "select" : "document",
-              "customtypes" : [ "event" ]
-            }
-          }
-        }
       }
     }
   }

--- a/prismic/custom-types/partner.json
+++ b/prismic/custom-types/partner.json
@@ -39,6 +39,20 @@
       "config" : {
         "label" : "Image URL"
       }
+    },
+    "event" : {
+      "type" : "Group",
+      "config" : {
+        "fields" : {
+          "data" : {
+            "type" : "Link",
+            "config" : {
+              "select" : "document",
+              "customtypes" : [ "event" ]
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR introduces the concept of Partners. I've added an association on the event so that we can reuse partners across different events later on.

There are two types of Partners:
* `Partner` is the entity on it's own
* `EventPartner` which also contains the partner level when partnering for that specific event
  (e.g. Gold, Silver, Bronze, Supporter)

I've fixed the existing tests, but could do with some guidance on adding further tests that actually give us some improved confidence in how the system operates.

https://trello.com/c/KlXsOLy5/70-add-partners-to-prismic-badger-brain

![Obligatory GIF Nonsense](http://i.giphy.com/xhXb2x70JWEcU.gif)