### PR TITLE
Adding support for speaker bio field

### DIFF
--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -108,6 +108,7 @@ export function sanitizeSpeaker(json) {
     githubHandle: get('speaker.githubHandle'),
     blogURL: get('speaker.blogURL'),
     imageURL: get('speaker.imageURL'),
+    bio: get('speaker.bio'),
   };
 }
 

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -159,6 +159,7 @@ describe('data/sanitize', () => {
           'speaker.githubHandle': { value: 'fff' },
           'speaker.blogURL': { value: 'ggg' },
           'speaker.imageURL': { value: 'hhh' },
+          'speaker.bio': { value: ['body'] },
         },
       };
       const result = sanitizeSpeaker(rawData);
@@ -170,6 +171,7 @@ describe('data/sanitize', () => {
         blogURL: 'ggg',
         imageURL: 'hhh',
         id: 'exampleId',
+        bio: ['body'],
       });
     });
   });

--- a/lib/speaker/speakerFields.js
+++ b/lib/speaker/speakerFields.js
@@ -4,6 +4,8 @@ import {
   GraphQLList,
 } from 'graphql';
 
+import { BodyStructuredTextType } from '../sharedTypes';
+
 import { fetchSpeaker, fetchAllSpeakers } from '../fetch';
 
 export const SpeakerType = new GraphQLObjectType({
@@ -36,6 +38,10 @@ export const SpeakerType = new GraphQLObjectType({
     imageURL: {
       type: GraphQLString,
       description: 'An URL link to the image of the speaker',
+    },
+    bio: {
+      type: new GraphQLList(BodyStructuredTextType),
+      description: 'Structured text in markdown with full description of the speaker',
     },
   },
 });

--- a/lib/speaker/speakerFields.spec.js
+++ b/lib/speaker/speakerFields.spec.js
@@ -29,6 +29,8 @@ describe('Speaker Queries', () => {
     const query = `
     query {
      	allSpeakers {
+        blogURL
+        imageURL
      	  id
         name
         company
@@ -48,6 +50,8 @@ describe('Speaker Queries', () => {
     query {
       speaker(id: "V35-XyMAAHMn1ugb") {
         id
+        blogURL
+        imageURL
         name
         company
         githubHandle

--- a/prismic/custom-types/speaker.json
+++ b/prismic/custom-types/speaker.json
@@ -48,6 +48,14 @@
       "config" : {
         "label" : "Image URL"
       }
+    },
+    "description" : {
+      "type" : "StructuredText",
+      "fieldset" : "Description",
+      "config" : {
+        "placeholder" : "Full speaker description in markdown",
+        "multi" : "p"
+      }
     }
   }
 }

--- a/test/fixtures/speakers.json
+++ b/test/fixtures/speakers.json
@@ -6,7 +6,9 @@
         "name": "Kadi Kraman",
         "company": "Red Badger",
         "githubHandle": "kadikraman",
-        "twitterHandle": "kadikraman"
+        "twitterHandle": "kadikraman",
+        "blogURL": "www.red-badger.com/blog",
+        "imageURL": "https://red-badger.com/images/profiles/profile_KKr_thumb_over.jpg"
       }
     ]
   }


### PR DESCRIPTION
![giphy](https://cloud.githubusercontent.com/assets/487468/18243952/814f53e4-7355-11e6-9512-63c0dfe8c654.gif)

### Motivation

React.london is implementing brand new page for conference speakers, and each speaker should be presented with a short bio copy.

### Pre-flight checklist

- [ ] Unit tests
- [ ] GraphiQL tested
- [ ] Client app tested
- [x] Gif added


