### PR TITLE
Production deploy script for prismic backup service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,6 @@ docs/.sass-cache
 docs/_site
 docs/Gemfile.lock
 
+
 **/.serverless
+prismic-backup-service/config/env.json

--- a/circle.yml
+++ b/circle.yml
@@ -25,4 +25,6 @@ deployment:
   staging:
     branch: master
     commands:
+      - npm install serverless@1.0.0-rc.1 -g
       - sudo bash ./bin/deploy.sh staging
+      - bash ./prismic-backup-service/bin/deploy-production.sh

--- a/prismic-backup-service/README.md
+++ b/prismic-backup-service/README.md
@@ -3,10 +3,20 @@ Prismic backup service
 
 Lambda that requests documents from prismic and stores the results in an S3 bucket.
 
-serverless 🙌
-
-```
+```sh
+# Install the Serverless CLI
 npm install serverless@1.0.0-rc.1 -g
+
+# Set up the dev environment variables
+cp config/env.example.json config/env.json
+vim config/env.json
+
+# Deploy the stack
 sls deploy
-sls invoke --function backupPrismic
+
+# Give it a test
+sls invoke --function BackupPrismic
+
+# Delete the stack (if you want to)
+sls remove
 ```

--- a/prismic-backup-service/bin/deploy-production.sh
+++ b/prismic-backup-service/bin/deploy-production.sh
@@ -29,5 +29,10 @@ echo Deploying prismic-backup-service to prod
 cd "$SERVICE_DIR"
 sls deploy --stage prod
 
+echo Creating new lambda version
+aws lambda publish-version \
+  --function-name prismic-backup-service-prod-BackupPrismic \
+  --region eu-west-1
+
 echo Cleanup
 rm "$ENV_FILE"

--- a/prismic-backup-service/bin/deploy-production.sh
+++ b/prismic-backup-service/bin/deploy-production.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+ENV_FILE="$SERVICE_DIR/config/env.json"
+
+echo Generating env.json
+
+cat > "$ENV_FILE" << Heredoc
+{
+  "bucketName": "redbadger-prismic-backup-prod",
+  "ErrorSNSSubscriptions": [
+    {
+      "Endpoint" : "$BADGER_LABS_SLACK_EMAIL",
+      "Protocol" : "email"
+    },
+    {
+      "Endpoint" : "$BADGER_LABS_EMAIL",
+      "Protocol" : "email"
+    }
+  ]
+}
+Heredoc
+
+echo Generated env.json
+
+echo Deploying prismic-backup-service to prod
+
+cd "$SERVICE_DIR"
+sls deploy --stage prod
+
+echo Cleanup
+rm "$ENV_FILE"

--- a/prismic-backup-service/bin/handler.js
+++ b/prismic-backup-service/bin/handler.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line strict
 const backup = require('../lib');
-const env = require('../config/env.json');
+const env = require('../config/env.json'); // eslint-disable-line import/no-unresolved
 
 module.exports.backupPrismic = (event, context, cb) => {
   backup(env.bucketName)

--- a/prismic-backup-service/bin/handler.js
+++ b/prismic-backup-service/bin/handler.js
@@ -4,18 +4,22 @@ const variables = require('../config/variables.json');
 
 const environment = (cb, functionName) => {
   switch (functionName) {
-    case 'prismic-backup-service-dev-backupPrismic':
+    case 'prismic-backup-service-dev-BackupPrismic':
       return variables.dev;
-    case 'prismic-backup-service-prod-backupPrismic':
+    case 'prismic-backup-service-prod-BackupPrismic':
       return variables.prod;
     default:
-      return cb('Unable to determine environment.');
+      return null;
   }
 };
 
 module.exports.backupPrismic = (event, context, cb) => {
   const env = environment(cb, context.functionName);
-  backup(env.bucketName)
-    .then(metadata => cb(null, metadata))
-    .catch(err => cb(err));
+  if (!env) {
+    cb(new Error('Unable to determine environment.'));
+  } else {
+    backup(env.bucketName)
+      .then(metadata => cb(null, metadata))
+      .catch(err => cb(err));
+  }
 };

--- a/prismic-backup-service/bin/handler.js
+++ b/prismic-backup-service/bin/handler.js
@@ -1,25 +1,9 @@
 'use strict'; // eslint-disable-line strict
 const backup = require('../lib');
-const variables = require('../config/variables.json');
-
-const environment = (cb, functionName) => {
-  switch (functionName) {
-    case 'prismic-backup-service-dev-BackupPrismic':
-      return variables.dev;
-    case 'prismic-backup-service-prod-BackupPrismic':
-      return variables.prod;
-    default:
-      return null;
-  }
-};
+const env = require('../config/env.json');
 
 module.exports.backupPrismic = (event, context, cb) => {
-  const env = environment(cb, context.functionName);
-  if (!env) {
-    cb(new Error('Unable to determine environment.'));
-  } else {
-    backup(env.bucketName)
-      .then(metadata => cb(null, metadata))
-      .catch(err => cb(err));
-  }
+  backup(env.bucketName)
+    .then(metadata => cb(null, metadata))
+    .catch(err => cb(err));
 };

--- a/prismic-backup-service/config/env.example.json
+++ b/prismic-backup-service/config/env.example.json
@@ -1,5 +1,5 @@
 {
-  "bucketName": "prismic-backup-dev",
+  "bucketName": "redbadger-prismic-backup-dev",
   "ErrorSNSSubscriptions": [
     {
       "Endpoint" : "YOUR-EMAIL-HERE",

--- a/prismic-backup-service/config/env.example.json
+++ b/prismic-backup-service/config/env.example.json
@@ -1,0 +1,9 @@
+{
+  "bucketName": "prismic-backup-dev",
+  "ErrorSNSSubscriptions": [
+    {
+      "Endpoint" : "YOUR-EMAIL-HERE",
+      "Protocol" : "email"
+    }
+  ]
+}

--- a/prismic-backup-service/config/variables.json
+++ b/prismic-backup-service/config/variables.json
@@ -1,8 +1,0 @@
-{
-  "dev": {
-    "bucketName": "prismic-backup-dev"
-  },
-  "prod": {
-    "bucketName": "prismic-backup-prod"
-  }
-}

--- a/prismic-backup-service/serverless.yml
+++ b/prismic-backup-service/serverless.yml
@@ -1,4 +1,4 @@
-service: prismic-backup-service # NOTE: update this with your service name
+service: prismic-backup-service
 
 custom:
   bucketName: prismic-backup-dev #${file(./config/variables.json)}
@@ -18,7 +18,7 @@ provider:
         - "arn:aws:s3:::${self:custom.bucketName}/*"
 
 functions:
-  backupPrismic:
+  BackupPrismic:
     handler: bin/handler.backupPrismic
 
 #   you can add any of the following events
@@ -37,3 +37,34 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: ${self:custom.bucketName}
+
+    ErrorSNSTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        Subscription:
+          - Endpoint: "zoe.bryant@red-badger.com"
+            Protocol: email
+          - Endpoint: "louis.pilfold@red-badger.com"
+            Protocol: email
+
+    LambdaErrorAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmActions:
+          - Ref: "ErrorSNSTopic"
+        AlarmDescription: "An error has been thrown by the lambda function responsible for backing up prismic data to S3."
+        AlarmName: PrismicBackupLambdaErrorAlarm
+          # TODO: see if we get a conflict AlarmName if we deploy two different versions.
+          # ie. dev/prod versions
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        Dimensions:
+          - Name: FunctionName
+            Value:
+              Ref: BackupPrismicLambdaFunction
+        EvaluationPeriods: 1
+        MetricName: Errors
+        Namespace: AWS/Lambda
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
+        Unit: Count

--- a/prismic-backup-service/serverless.yml
+++ b/prismic-backup-service/serverless.yml
@@ -20,15 +20,8 @@ provider:
 functions:
   BackupPrismic:
     handler: bin/handler.backupPrismic
-
-#   you can add any of the following events
-#   events:
-#     - http:
-#         path: users/create
-#         method: get
-#     - s3: ${bucket}
-#     - schedule: rate(10 minutes)
-#     - sns: greeter-topic
+    events:
+      - schedule: rate(1 day)
 
 resources:
   Resources:
@@ -48,9 +41,7 @@ resources:
         AlarmActions:
           - Ref: "ErrorSNSTopic"
         AlarmDescription: "An error has been thrown by the lambda function responsible for backing up prismic data to S3."
-        AlarmName: PrismicBackupLambdaErrorAlarm
-          # TODO: see if we get a conflict AlarmName if we deploy two different versions.
-          # ie. dev/prod versions
+        AlarmName: PrismicBackupLambdaErrorAlarm-${opt:stage, self:provider.stage}
         ComparisonOperator: GreaterThanOrEqualToThreshold
         Dimensions:
           - Name: FunctionName

--- a/prismic-backup-service/serverless.yml
+++ b/prismic-backup-service/serverless.yml
@@ -1,7 +1,7 @@
 service: prismic-backup-service
 
 custom:
-  bucketName: prismic-backup-dev #${file(./config/variables.json)}
+  bucketName: ${file(./config/env.json):bucketName}
 
 provider:
   name: aws
@@ -30,7 +30,6 @@ functions:
 #     - schedule: rate(10 minutes)
 #     - sns: greeter-topic
 
-# you can add CloudFormation resource templates here
 resources:
   Resources:
     BackupBucket:
@@ -41,11 +40,7 @@ resources:
     ErrorSNSTopic:
       Type: AWS::SNS::Topic
       Properties:
-        Subscription:
-          - Endpoint: "zoe.bryant@red-badger.com"
-            Protocol: email
-          - Endpoint: "louis.pilfold@red-badger.com"
-            Protocol: email
+        Subscription: ${file(./config/env.json):ErrorSNSSubscriptions}
 
     LambdaErrorAlarm:
       Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
work with @lpil 
## Gif

![](http://i.giphy.com/sI1nxDImcVNao.gif)

## Motivation
[Trello Ticket](https://trello.com/c/Y4X7cGGO)

A follow on from #77 which contains a lambda function to backup prismic once a day.
It wasn't quite complete, however, as it could not distinguish between dev and prod, and it did not send notifications if anything failed.

## Testing this ticket
When code is merged to master, the deploy-production.sh script will run, and you should see an updated version number on the lambda

## Features in this PR

- Added versions so we can roll back lambda versions if needed
- Added deploy script so we can have dev and prod backups
- Added a CloudWatch Alarm so when the function fails we get a SNS topic sent to email addresses set in an env variable (CircleCI has been updated)

## Features not in this PR

- The ability to detect that a deploy to production is not actually necessary. We explored some ways to do this but decided it wasn't particularly a priority in the end. It does mean that the version will update every time we merge to master, which might make it difficult to tell what to roll back to if many versions are duplicates of each other.
- A notification when the function has been successful. Again, we explored some ways to do this and couldn't find a fix, so chose to reprioritise for now.