### PR TITLE
Renaming partnership levels

### DIFF
--- a/lib/event-partner/index.js
+++ b/lib/event-partner/index.js
@@ -12,9 +12,9 @@ const LevelType = new GraphQLEnumType({
   name: 'LevelType',
   values: {
     Supporter: { value: 'Supporter' },
-    Gold: { value: 'Gold' },
-    Silver: { value: 'Silver' },
-    Bronze: { value: 'Bronze' },
+    Pioneer: { value: 'Pioneer' },
+    Explorer: { value: 'Explorer' },
+    Trekker: { value: 'Trekker' },
   },
 });
 


### PR DESCRIPTION
Changing GraphQL schema to accommodate new event partnership level names.