### PR TITLE
Added defensive check for empty skills

### DIFF
--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -149,7 +149,7 @@ export function sanitizeBadger(json) {
     imageUrl: get('badger.image-url'),
     startDate: get('badger.start-date'),
     about: get('badger.about'),
-    skills: (get('badger.skills') || []).map(data => data.skill.value),
+    skills: (get('badger.skills') || []).filter(data => data.skill).map(data => data.skill.value),
     influence: get('badger.influence'),
     achievements: get('badger.achievements'),
     linkedin: pathOr(null, ['url'], get('badger.linkedin')),

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -461,6 +461,28 @@ describe('data/sanitize', () => {
         lastName: 'Nikolaievich-Savin',
       });
     });
+
+    it('ignores empty skills', () => {
+      const rawData = {
+        id: 'badgerId',
+        data: {
+          'badger.skills': { value: [
+            { skill: { type: 'Text', value: 'Programming' } },
+            {},
+            { skill: { type: 'Text', value: 'JavaScript' } },
+            {},
+          ] },
+        },
+        tags: [
+        ],
+      };
+      const result = sanitizeBadger(rawData);
+      expect(result).to.deep.equal({
+        ...baseBadger,
+        id: 'badgerId',
+        skills: ['Programming', 'JavaScript'],
+      });
+    });
   });
 
   describe('sanitizeTicket', () => {


### PR DESCRIPTION
Adding an empty skill creates a blank object in the skills array. Catered for this in `santizeBadger` so that empty skills aren't returned from the GraphQL layer
