### PR TITLE
Ensured Badger image Urls are always returned as https

### DIFF
--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -139,6 +139,7 @@ const categories = {
 export function sanitizeBadger(json) {
   const get = makeGetter(json);
   const name = get('badger.name');
+  const imageUrl = get('badger.image-url');
   return {
     id: json.id,
     slug: json.uid,
@@ -146,7 +147,7 @@ export function sanitizeBadger(json) {
     lastName: name && name.split(' ').slice(-1).join(' '),
     order: get('badger.order'),
     jobTitle: get('badger.job-title'),
-    imageUrl: get('badger.image-url'),
+    imageUrl: imageUrl && imageUrl.replace(/^http:/, 'https:'),
     startDate: get('badger.start-date'),
     about: get('badger.about'),
     skills: (get('badger.skills') || []).filter(data => data.skill).map(data => data.skill.value),

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -276,7 +276,7 @@ describe('data/sanitize', () => {
           'badger.name': { value: 'Alex Savin' },
           'badger.order': { value: 1 },
           'badger.job-title': { value: 'Technical Lead' },
-          'badger.image-url': { value: 'http://face.gif' },
+          'badger.image-url': { value: 'https://face.gif' },
           'badger.start-date': { value: '05-12-2016' },
           'badger.about': { value: 'I like CSS' },
           'badger.skills': { value: [
@@ -302,7 +302,7 @@ describe('data/sanitize', () => {
         lastName: 'Savin',
         order: 1,
         jobTitle: 'Technical Lead',
-        imageUrl: 'http://face.gif',
+        imageUrl: 'https://face.gif',
         startDate: '05-12-2016',
         about: 'I like CSS',
         skills: ['Programming', 'JavaScript'],
@@ -481,6 +481,23 @@ describe('data/sanitize', () => {
         ...baseBadger,
         id: 'badgerId',
         skills: ['Programming', 'JavaScript'],
+      });
+    });
+
+    it('converts http to https in image url', () => {
+      const rawData = {
+        id: 'badgerId',
+        data: {
+          'badger.image-url': { value: 'http://photo.png' },
+        },
+        tags: [
+        ],
+      };
+      const result = sanitizeBadger(rawData);
+      expect(result).to.deep.equal({
+        ...baseBadger,
+        id: 'badgerId',
+        imageUrl: 'https://photo.png',
       });
     });
   });


### PR DESCRIPTION
It's easy to accidentally copy an `http` image Url out of cloudinary and paste it into Prismic. But this prevents the image showing up in the website because the website is `https`. So, changed the `sanitizeBadger` function to convert image Urls from `http` to `https`.
