### PR TITLE
Enabling logic for Events featured images to have full URL

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,4 @@
+export const imageAssetsEndpoint =
+  'https://res.cloudinary.com/red-badger-assets/image/upload/events/';
+
+export const defaultEventImage = 'red-badger-event.jpg';

--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -1,5 +1,6 @@
 import { pathOr } from 'ramda';
 import { expandTimestamp } from '../utilities/dates';
+import { imageAssetsEndpoint, defaultEventImage } from '../config';
 
 function makeGetter(json) {
   return key => pathOr(null, ['data', key, 'value'], json);
@@ -15,6 +16,19 @@ export function reformatLinkList(linkList) {
     newLink.type = link.type || { value: 'OTHER' };
     return newLink;
   });
+}
+
+export function eventImagePath(
+  featureImageFilename) {
+  const f = featureImageFilename || defaultEventImage;
+
+  // Check if we already have full URL for the featured image
+  if (/\/\//.test(featureImageFilename)) {
+    // Check and convert http:// to https://
+    return featureImageFilename.replace(/^http:\/\//, 'https://');
+  }
+
+  return imageAssetsEndpoint + f;
 }
 
 // TODO: Determine correct behaviour and split into two functions.
@@ -40,7 +54,7 @@ function sanitizeEventAndNews(item, type) {
     externalLinks: reformatLinkList(get(`${type}.externalLinks`)),
     tickets: get(`${type}.tickets`) || [],
     body: get(`${type}.body`) || [],
-    featureImageFilename: get(`${type}.${imageField}`),
+    featureImageFilename: eventImagePath(get(`${type}.${imageField}`)),
     talks: get('event.talks') || [],
     schedule: get(`${type}.schedule`) || [],
     sponsors: get(`${type}.sponsors`) || [],

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -13,7 +13,9 @@ import {
   sanitizeBadger,
 } from './sanitize';
 
-describe('data/sanitize', () => {
+import { imageAssetsEndpoint, defaultEventImage } from '../config';
+
+describe.only('data/sanitize', () => {
   describe('sanitizeEvent', () => {
     it('should sanitate empty fields', () => {
       const event = deepFreeze({
@@ -30,7 +32,7 @@ describe('data/sanitize', () => {
         eventType: null,
         strapline: null,
         featuredEventDescription: null,
-        featureImageFilename: null,
+        featureImageFilename: `${imageAssetsEndpoint}${defaultEventImage}`,
         internalLinks: [],
         externalLinks: [],
         datetime: null,
@@ -92,7 +94,7 @@ describe('data/sanitize', () => {
         eventType: 'Meetup',
         strapline: 'A strapline!',
         featuredEventDescription: 'some description',
-        featureImageFilename: 'foo.png',
+        featureImageFilename: `${imageAssetsEndpoint}foo.png`,
         internalLinks: [],
         externalLinks: [],
         datetime: null,
@@ -118,6 +120,39 @@ describe('data/sanitize', () => {
       };
 
       expect(sanitizeEvent(event)).to.deep.equal(emptyResponse);
+    });
+
+    it('should preserve full URL of the event image', () => {
+      const event = deepFreeze({
+        id: '123',
+        data: {
+          'event.event-image': { value: 'https://example.com/foo.png' },
+        },
+      });
+      const result = sanitizeEvent(event);
+      expect(result.featureImageFilename).to.equal('https://example.com/foo.png');
+    });
+
+    it('should convert http URL of the event image into https', () => {
+      const event = deepFreeze({
+        id: '123',
+        data: {
+          'event.event-image': { value: 'http://example.com/foo.png' },
+        },
+      });
+      const result = sanitizeEvent(event);
+      expect(result.featureImageFilename).to.equal('https://example.com/foo.png');
+    });
+
+    it('should append URL of the featured image if no full URL is available', () => {
+      const event = deepFreeze({
+        id: '123',
+        data: {
+          'event.event-image': { value: 'foo.png' },
+        },
+      });
+      const result = sanitizeEvent(event);
+      expect(result.featureImageFilename).to.equal(`${imageAssetsEndpoint}foo.png`);
     });
 
 


### PR DESCRIPTION
Moving logic from Website Honestly to Badger Brain

Related discussion: https://github.com/redbadger/website-honestly/pull/377#discussion_r101275725

### Pre-flight checklist

- [x] Unit tests
- [x] GraphiQL tested
- [x] Client app tested
- [ ] Gif added

p.s. giphy.com is broken :-O