### PR TITLE
add careerBrief attribute to the organisation

### DIFF
--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -96,6 +96,7 @@ export function sanitizeOrganisation(json) {
     id: json.id,
     name: get('organisation.name'),
     description: get('organisation.description'),
+    careerBrief: get('organisation.careerBrief'),
     url: get('organisation.URL'),
     imageURL: get('organisation.imageURL'),
     jobs: get('organisation.jobs') || [],

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -227,6 +227,7 @@ describe.only('data/sanitize', () => {
         data: {
           'organisation.name': { value: 'exampleName' },
           'organisation.description': { value: 'exampleDescription' },
+          'organisation.careerBrief': { value: 'exampleCareerBrief' },
           'organisation.URL': { value: 'exampleURL' },
           'organisation.imageURL': { value: 'exampleImageURL' },
           'organisation.jobs': { value: ['job1', 'job2'] },
@@ -237,6 +238,7 @@ describe.only('data/sanitize', () => {
         id: 'exampleId',
         name: 'exampleName',
         description: 'exampleDescription',
+        careerBrief: 'exampleCareerBrief',
         url: 'exampleURL',
         imageURL: 'exampleImageURL',
         jobs: ['job1', 'job2'],
@@ -253,6 +255,7 @@ describe.only('data/sanitize', () => {
         id: null,
         name: null,
         description: null,
+        careerBrief: null,
         url: null,
         imageURL: null,
         jobs: [],

--- a/lib/interfaces/organisation/index.js
+++ b/lib/interfaces/organisation/index.js
@@ -43,6 +43,10 @@ export const organisationTypeFields = {
     type: GraphQLString,
     description: 'Description of organisation',
   },
+  careerBrief: {
+    type: GraphQLString,
+    description: 'General jobs description',
+  },
   url: {
     type: GraphQLString,
     description: 'URL for organisation homepage',

--- a/prismic/custom-types/organisation.json
+++ b/prismic/custom-types/organisation.json
@@ -20,6 +20,12 @@
         "label": "Description (Max 50 Characters)"
       }
     },
+    "careerBrief": {
+      "type": "Text",
+      "config": {
+        "label": "Career Brief (Max 50 Characters)"
+      }
+    },
     "URL": {
       "type": "Text",
       "config": {


### PR DESCRIPTION
### Pre-flight checklist

* allows badger brain to return `careerBrief` field for the requested organisation

- [ ] Unit tests
- [ ] GraphiQL tested
- [ ] Client app tested
- [ ] Gif added

