### PR TITLE
Removed italics option when formatting answer

### DIFF
--- a/prismic/custom-types/q-and-a.json
+++ b/prismic/custom-types/q-and-a.json
@@ -10,7 +10,7 @@
     "answer" : {
       "type" : "StructuredText",
       "config" : {
-        "multi" : "paragraph, strong, em, hyperlink",
+        "multi" : "paragraph, strong, hyperlink",
         "label" : "Answer",
         "placeholder" : "Write your answer"
       }


### PR DESCRIPTION
Checked with UX and italics aren't required in Q & A slice answers (only bold and links)

### Pre-flight checklist

- [ ] Unit tests
- [x] GraphiQL tested
- [x] Client app tested
- [ ] Gif added

