### PR TITLE
add order to q and a fields

### DIFF
--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -221,6 +221,7 @@ export function sanitizeQnA(json) {
     slug: json.slug,
     name: get('q-and-a-category.category-name'),
     topics: get('q-and-a-category.q-n-a-list'),
+    order: get('q-and-a-category.order'),
   };
   return category;
 }
@@ -231,5 +232,6 @@ export function sanitizeQnATopic(json) {
     slug: json.slug,
     question: get('q-and-a.question'),
     answer: new Prismic.Fragments.StructuredText(get('q-and-a.answer')).asHtml(),
+    order: get('q-and-a.order'),
   };
 }

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -653,6 +653,7 @@ describe.only('data/sanitize', () => {
           data: {
             'q-and-a-category.category-name': { value: 'Projects' },
             'q-and-a-category.q-n-a-list': { value: 'topics' },
+            'q-and-a-category.order': { value: 1 },
           },
         };
         const result = sanitizeQnA(rawData);
@@ -660,6 +661,7 @@ describe.only('data/sanitize', () => {
           name: 'Projects',
           slug: 'projects',
           topics: 'topics',
+          order: 1,
         });
       },
     );
@@ -704,6 +706,7 @@ describe.only('data/sanitize', () => {
                 spans: [],
               },
             ] },
+            'q-and-a.order': { value: 2 },
           },
         };
         const result = sanitizeQnATopic(rawData);
@@ -711,6 +714,7 @@ describe.only('data/sanitize', () => {
           slug: 'how-much-will-my-project-cost',
           question: 'How much will my project cost?',
           answer: '<p>This is totally dependent on your requirements, but <strong>Red Badger’s</strong> value is in the total cost of ownership, i.e we have proven time and again that we always deliver and speed projects to market so total costs always end up being less than using a competitor whose day-rate might be cheaper, but would take <a href="https://red-badger.com">longer</a>.</p><p>Obviously all projects are completely different, a further discussion would be needed to ascertain a time-line but Red Badger are known for their speed to market.  We can always advise on a rough time-scale once we’ve had an initial brief and will be able to forecast in more accuracy once the project is complete.</p>',
+          order: 2,
         });
       },
     );

--- a/lib/q-and-a/q-and-a-fields.js
+++ b/lib/q-and-a/q-and-a-fields.js
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLList, GraphQLObjectType } from 'graphql';
+import { GraphQLString, GraphQLList, GraphQLObjectType, GraphQLInt } from 'graphql';
 import { pathOr } from 'ramda';
 import { fetchAllQnA, fetchQnATopic } from '../fetch';
 
@@ -16,6 +16,10 @@ const QnATopicType = new GraphQLObjectType({
     answer: {
       type: GraphQLString,
       description: 'Full text of the answer',
+    },
+    order: {
+      type: GraphQLInt,
+      description: 'Order of the item',
     },
   },
 });
@@ -43,6 +47,10 @@ const QnACategoryType = new GraphQLObjectType({
         }
         return [];
       },
+    },
+    order: {
+      type: GraphQLInt,
+      description: 'Order of the item',
     },
   },
 });

--- a/lib/q-and-a/q-and-a-fields.spec.js
+++ b/lib/q-and-a/q-and-a-fields.spec.js
@@ -32,6 +32,7 @@ describe('Q and A Queries', () => {
           slug
           question
           answer
+          order
         }
       }
     }

--- a/prismic/custom-types/q-and-a-category.json
+++ b/prismic/custom-types/q-and-a-category.json
@@ -22,6 +22,12 @@
           }
         }
       }
+    },
+    "order" : {
+      "type" : "Number",
+      "config" : {
+        "label" : "Order"
+      }
     }
   }
 }

--- a/prismic/custom-types/q-and-a.json
+++ b/prismic/custom-types/q-and-a.json
@@ -14,6 +14,12 @@
         "label" : "Answer",
         "placeholder" : "Write your answer"
       }
+    },
+    "order" : {
+      "type" : "Number",
+      "config" : {
+        "label" : "Order"
+      }
     }
   }
 }


### PR DESCRIPTION
### Pre-flight checklist

In prismic there are now order fields for `Q and A category` and `Q and A Item`.

- [ ] Unit tests
- [ ] GraphiQL tested
- [ ] Client app tested
- [ ] Gif added

