### PR TITLE
Use UID for SEO friendly unique URL as per Prismic docs

### DIFF
--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -218,7 +218,7 @@ export function sanitizeBadger(json) {
 export function sanitizeQnA(json) {
   const get = makeGetter(json);
   const category = {
-    slug: json.slug,
+    slug: json.uid,
     name: get('q-and-a-category.category-name'),
     topics: get('q-and-a-category.q-n-a-list'),
     order: get('q-and-a-category.order'),
@@ -229,7 +229,7 @@ export function sanitizeQnA(json) {
 export function sanitizeQnATopic(json) {
   const get = makeGetter(json);
   return {
-    slug: json.slug,
+    slug: json.uid,
     question: get('q-and-a.question'),
     answer: new Prismic.Fragments.StructuredText(get('q-and-a.answer')).asHtml(),
     order: get('q-and-a.order'),
@@ -241,7 +241,7 @@ export function sanitizeWebinar(json) {
 
   return {
     id: json.id,
-    slug: json.slug,
+    slug: json.uid,
     title: get('webinar.title'),
     startDateTime: get('webinar.timestamp'),
     endDateTime: pathOr(get('webinar.timestamp'),

--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -46,7 +46,7 @@ function sanitizeEventAndNews(item, type) {
 
   return {
     id: item.id,
-    slug: item.slug || null,
+    slug: item.uid || null,
     tags: item.tags || [],
     eventType: get(`${type}.eventType`),
     title: get(`${type}.title`),

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -650,7 +650,7 @@ describe('data/sanitize', () => {
       'converts the raw json provided by prismic to be readable by graphql',
       () => {
         const rawData = {
-          slug: 'projects',
+          uid: 'projects',
           data: {
             'q-and-a-category.category-name': { value: 'Projects' },
             'q-and-a-category.q-n-a-list': { value: 'topics' },
@@ -674,7 +674,7 @@ describe('data/sanitize', () => {
       () => {
         const rawData = {
           id: 'exampleId',
-          slug: 'how-much-will-my-project-cost',
+          uid: 'how-much-will-my-project-cost',
           data: {
             'q-and-a.question': { value: 'How much will my project cost?' },
             'q-and-a.answer': { value: [
@@ -760,7 +760,7 @@ describe('data/sanitize', () => {
     it('converts the raw json provided by prismic to be readable by graphql', () => {
       const rawData = {
         id: 'exampleId',
-        slug: 'exampleSlug',
+        uid: 'exampleSlug',
         data: {
           'webinar.title': { value: 'aaa' },
           'webinar.timestamp': { value: '01-01-2017' },
@@ -788,7 +788,7 @@ describe('data/sanitize', () => {
     it('returns the default values if the fields are not passed from prismic', () => {
       const rawData = {
         id: null,
-        slug: null,
+        uid: null,
         data: {},
       };
       const result = sanitizeWebinar(rawData);
@@ -798,7 +798,7 @@ describe('data/sanitize', () => {
     it('should copy start datetime to end datetime when end datetime is empty', () => {
       const rawData = {
         id: 'exampleId',
-        slug: 'exampleSlug',
+        uid: 'exampleSlug',
         data: {
           'webinar.timestamp': { value: '01-01-2017' },
           'webinar.timestampEnd': null,

--- a/lib/fetch/sanitize.spec.js
+++ b/lib/fetch/sanitize.spec.js
@@ -66,7 +66,7 @@ describe('data/sanitize', () => {
     it('should extract real values', () => {
       const event = deepFreeze({
         id: '123',
-        slug: 'some-event',
+        uid: 'event-title',
         tags: ['tag1', 'tag2'],
         data: {
           'event.title': { value: 'Event Title' },
@@ -91,10 +91,10 @@ describe('data/sanitize', () => {
 
       const emptyResponse = {
         id: '123',
+        slug: 'event-title',
         tags: ['tag1', 'tag2'],
         title: 'Event Title',
         calendarURL: 'Event Calendar URL',
-        slug: 'some-event',
         eventType: 'Meetup',
         strapline: 'A strapline!',
         featuredEventDescription: 'some description',


### PR DESCRIPTION
Fixes redbadger/website-honestly#436

Currently we use the `slug` provided by _Prismic_ but this value will change every time the `title` is changed in _Prismic_. _Prismic_ will maintain a `slugs` list of all values used as the `slug` and the current `slug` value will be from the latest `title` update.

The problem being fixed here is that Prismic doesn't make unique `slugs`, this means that if two pieces of content have the same `title` then they will have the same `slug` leading to only one of the items being navigatable on the site.

We fix this by using the UID generated by _Prismic_ that can be edited but is always unique. _Prismic_ actually recommend the use of the UID as a SEO friendly unique URL identifier.

### Pre-flight checklist

- [ ] Unit tests
- [ ] GraphiQL tested
- [ ] Client app tested
- [ ] Gif added

