### PR TITLE
Sequentially get all pages from Prismic

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -28,24 +28,33 @@ async function fetchOne(docType, sanitizeFunction, args) {
   return {};
 }
 
+async function queryPrismic(api, query, page) {
+  return await api
+    .form('everything')
+    .ref(api.master())
+    .query(query)
+    .pageSize(100) // Max supported by api
+    .page(page)
+    .submit();
+}
+
 async function fetchAll(docType, sanitizeFunction, args) {
   const query = [Prismic.Predicates.at('document.type', docType)];
   if (args && args.tag) {
     query.push(Prismic.Predicates.at('document.tags', [args.tag]));
   }
   const api = await Prismic.api(PrismicConfig.apiEndpoint);
-  const res = await api
-    .form('everything')
-    .ref(api.master())
-    .query(query)
-    .pageSize(100) // TODO: implement pagination
-    .submit();
+  let res = await queryPrismic(api, query, 1);
 
-  if (res && res.results.length > 0) {
-    return res.results.map((item) => sanitizeFunction(item, docType));
+  const results = [...res.results];
+  while (res.next_page != null) {
+    res = await queryPrismic(api, query, res.page + 1);
+    results.push(...res.results);
   }
-  return [];
+
+  return results.map((item) => sanitizeFunction(item, docType));
 }
+
 
 // Community
 export function fetchAllCommunities() {


### PR DESCRIPTION
Fixes: redbadger/website-honestly#435

The Prismic api has a max page size of 100 items, this has been fine while the number of badgers has been below this number.

This fix repeatedly calls the Prismic api while there are more pages available before santizing all items.

### Pre-flight checklist

- [ ] Unit tests
- [ ] GraphiQL tested
- [ ] Client app tested
- [ ] Gif added

