### PR TITLE
stops throwing errors when hubspot forms are missing. Prismic is bad

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -24,9 +24,7 @@ export async function fetchHubspotForm(args) {
   const response = await fetch(HubspotConfig.formsApiEndpoint(args.id));
   const result = await response.json();
   if (result.status && result.status === 'error') {
-    throw new Error(
-      'Could not find hubspot form. A valid hubspot form ID is required for Gold Coin pages.'
-    );
+    return null;
   }
   return sanitizeHubspotForm(result);
 }

--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -273,6 +273,7 @@ export async function sanitizeGoldCoinPage(json, options) {
   ]);
   const hubspotForm = await options.formFetcher({
     id: get('gold_coin_page.hubspot_form_id'),
+    slug: json.slug,
   });
   return {
     slug: json.slug,

--- a/lib/goldCoinPage/goldCoinPageFields.js
+++ b/lib/goldCoinPage/goldCoinPageFields.js
@@ -62,7 +62,8 @@ export const GoldCoinPage = new GraphQLObjectType({
     },
     consultants: {
       type: new GraphQLList(GraphQLString),
-      description: 'Slugs of the Consultant(s)/Badger(s) who will conduct the session',
+      description:
+        'Slugs of the Consultant(s)/Badger(s) who will conduct the session',
     },
     hubspotForm: {
       type: HubspotForm,


### PR DESCRIPTION
Prismic doesn't let you setup required fields. Meaning you either have to validate content elsewhere or just not worry about what content is getting checked around.

GraphQL doesn't let you filter out null results.

This change removes errors for invalid content types prevent null results.

It's not the perfect fix, but prismic's poor UX means it's this or leave our CMS open to errors.
