### PR TITLE
Removes html tags from consent labelling

### DIFF
--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -461,7 +461,7 @@ function sanitizeHubspotFormFields(fields) {
 function sanitizeHubspotCheckboxes(json) {
   if (json) {
     return {
-      label: sanitizeHtml(json.label).replace(/<[^>]+>/g, ''),
+      label: json.label.replace(/<[^>]+>/g, ''),
       required: json.required,
     };
   }
@@ -474,9 +474,10 @@ function sanitizeHubspotConsentData(json) {
   );
   if (rawData) {
     return {
-      consentMessage: sanitizeHtml(
-        rawData.processingConsentCheckboxLabel
-      ).replace(/<[^>]+>/g, ''),
+      consentMessage: rawData.processingConsentCheckboxLabel.replace(
+        /<[^>]+>/g,
+        ''
+      ),
       checkboxes: rawData.communicationConsentCheckboxes.map(
         sanitizeHubspotCheckboxes
       ),

--- a/lib/fetch/sanitize.js
+++ b/lib/fetch/sanitize.js
@@ -454,10 +454,14 @@ function sanitizeHubspotFormFields(fields) {
   });
 }
 
+// Hubspot serves these labels as HTML with tags
+// There is no way to turn this off in Hubspot
+// So the tags get removed here
+
 function sanitizeHubspotCheckboxes(json) {
   if (json) {
     return {
-      label: sanitizeHtml(json.label),
+      label: sanitizeHtml(json.label).replace(/<[^>]+>/g, ''),
       required: json.required,
     };
   }
@@ -470,7 +474,9 @@ function sanitizeHubspotConsentData(json) {
   );
   if (rawData) {
     return {
-      consentMessage: sanitizeHtml(rawData.processingConsentCheckboxLabel),
+      consentMessage: sanitizeHtml(
+        rawData.processingConsentCheckboxLabel
+      ).replace(/<[^>]+>/g, ''),
       checkboxes: rawData.communicationConsentCheckboxes.map(
         sanitizeHubspotCheckboxes
       ),


### PR DESCRIPTION
### Pre-flight checklist

- [ ] Unit tests
- [ ] GraphiQL tested
- [ ] Client app tested
- [ ] Gif added

